### PR TITLE
Updated build scripts for clarity

### DIFF
--- a/OneFlow/Start-Release.ps1
+++ b/OneFlow/Start-Release.ps1
@@ -16,6 +16,9 @@ using module '../PsModules/RepoBuild/RepoBuild.psd1'
 Param([string]$commit = "")
 $buildInfo = Initialize-BuildEnvironment
 
+$officialRemoteName = Get-GitRemoteName $buildInfo official
+$forkRemoteName = Get-GitRemoteName $buildInfo fork
+
 # create new local branch for the release
 $branchName = "release/$(Get-BuildVersionTag $buildInfo)"
 Write-Information "Creating release branch in local repo"
@@ -29,10 +32,10 @@ else
 }
 
 # push to fork so that changes go through normal PR process
-Write-Information "Pushing branch to origin"
-Invoke-External git push origin -u $branchName
+Write-Information "Pushing branch to fork"
+Invoke-External git push $forkRemoteName -u $branchName
 
 # Push to product repo so it is clear to all a release
 # is in process.
-Write-Information "Pushing branch to upstream"
-Invoke-External git push upstream $branchName
+Write-Information "Pushing branch to official repository (Push/Write permission required)"
+Invoke-External git push $officialRemoteName $branchName

--- a/PsModules/CommonBuild/CommonBuild.psd1
+++ b/PsModules/CommonBuild/CommonBuild.psd1
@@ -75,7 +75,10 @@ FunctionsToExport = @(
     'Expand-ArchiveStream',
     'Expand-StreamFromUri',
     'Find-OnPath',
+    'Get-BuildVersionTag',
     'Get-CurrentBuildKind',
+    'Get-GitRemotes',
+    'Get-GitRemoteName',
     'Get-GitHubReleases',
     'Get-GitHubTaggedRelease',
     'Initialize-CommonBuildEnvironment',
@@ -83,8 +86,7 @@ FunctionsToExport = @(
     'Invoke-TimedBlock',
     'New-CmakeSettings',
     'Show-FullBuildInfo'
-)
-# Cmdlets to export from this module
+)# Cmdlets to export from this module
 CmdletsToExport = '*'
 
 # Variables to export from this module

--- a/PsModules/CommonBuild/Public/Get-GitRemotes.ps1
+++ b/PsModules/CommonBuild/Public/Get-GitRemotes.ps1
@@ -1,0 +1,42 @@
+function Get-GitRemotes
+{
+    param($opName = "push")
+    $remoteLines = ((git remote -v) -split [System.Environment]::NewLine)
+    $retVal = [System.Collections.ArrayList]@()
+    foreach($remoteLine in $remoteLines)
+    {
+        if( $remoteLine -match '([^\s]+)\s+([^\s]+)\s+\(([^\s]+)\)')
+        {
+            if($matches[3] -eq $opName)
+            {
+                $hashTable =@{
+                    Name = $matches[1]
+                    Uri = $matches[2]
+                    Op = $matches[3]
+                }
+
+                $retVal.Add($hashTable) | Out-Null
+            }
+        }
+        else
+        {
+            throw "'$remoteLine' - does not match pattern for a valid git remote..."
+        }
+    }
+
+    return $retVal
+}
+
+function Get-GitRemoteName
+{
+    param([hashtable]$bldInfo, [ValidateSet('official', 'fork')] $kind)
+
+    if($kind -eq 'official')
+    {
+        Get-GitRemotes | ? {$_.Uri -eq $bldInfo['OfficialGitRemoteUrl']} | Select -ExpandProperty Name
+    }
+    else
+    {
+        Get-GitRemotes | ? {$_.Uri -ne $bldInfo['OfficialGitRemoteUrl']} | Select -ExpandProperty Name
+    }
+}


### PR DESCRIPTION
Updated build scripts for clarity on 'official' vs  'fork' remote names (origin and upstream) are WAY to overloaded to have precise meaning (and sometimes are even considered synonymous).
* Getting to clarity on actual behavior of the scripts is a complex beast due to all the assumptions on the internet.