### PR TITLE
Apparently syntax of path-ignores requires quoting.

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,8 +7,8 @@ on:
 
     paths-ignore:
       - '**.md'
-      - .github/workflows/release-build.yml
-      - OneFlow/*.*
+      - '.github/workflows/release-build.yml'
+      - 'OneFlow/*.*'
 
   pull_request:
     branches:
@@ -17,8 +17,8 @@ on:
 
     paths-ignore:
       - '**.md'
-      - .github/workflows/release-build.yml
-      - OneFlow/*.*
+      - '.github/workflows/release-build.yml'
+      - 'OneFlow/*.*'
 
 jobs:
   build_target:


### PR DESCRIPTION
* Sadly there's no way to prevalidate the syntax of actions
* Even worse, it seems to silently ignore non-quoted values...

NOTE: changes to the action itself will trigger a build as it isn't clear if the changes themselves impact a binary build or not.

It is safe to skip such a build in this case as it only changes the actions logic on what to skip.