### PR TITLE
Updated NuGet push stage to report errors in secrets

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -70,7 +70,17 @@ jobs:
         run: dir BuildOutput/Nuget
 
       - name: Publish packages to NuGet.org
-          run: dotnet nuget push .\BuildOutput\NuGet\*.nupkg -k ${{ secrets.NUGETPUSH_ACCESS_TOKEN }} -s 'https://api.nuget.org/v3/index.json' --skip-duplicate
+        run: |
+          if( [string]::IsNullOrWhitesapce())
+          {
+              throw "NUGETPUSH_ACCESS_TOKEN" does not exist"
+          }
+          $response = Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/" -Headers @{ Authorization = "Bearer ${{ secrets.NUGETPUSH_ACCESS_TOKEN }}" }
+          if ($response.StatusCode -ne 200)
+          {
+              throw "Invalid or expired API key"
+          }
+          dotnet nuget push .\BuildOutput\NuGet\*.nupkg -k ${{ secrets.NUGETPUSH_ACCESS_TOKEN }} -s 'https://api.nuget.org/v3/index.json' --skip-duplicate
 
       - name: Create Release
         if: (!cancelled())


### PR DESCRIPTION
Updated NuGet push stage to report errors in secret
* For reasons currently unknown, the release NuGet Push is failing, yet if the packages are downloaded and the command run locally all works. Thus, the presumption is that something is wrong with the access token. This is intended to aid in identifying what that is...