### PR TITLE
Restored support for StyleCop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,6 @@ AppPackages/
 
 # Others
 ClientBin/
-[Ss]tyle[Cc]op.*
 ~$*
 *~
 *.dbmdl

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -102,6 +102,12 @@
         For an explanation of the benefits of the language feature
         see: https://www.hanselman.com/blog/implicit-usings-in-net-6
         -->
-        <Error Condition="'$(ImplicitUsings)'!='disable'" Text="$(MSBuildProjectFile) - Projects in this repository MUST NOT have ImplicitUsings enabled!"/>
+        <Error Code="DBT001" Condition="'$(ImplicitUsings)'!='disable'" Text="$(MSBuildProjectFile) - Projects in this repository MUST NOT have ImplicitUsings enabled!"/>
+
+        <!--
+        Until issue https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3902 is resolved directly test for missing file
+        as this has impacted this repo once already...
+        -->
+        <Error Code="DBT002" Condition="!Exists('$(MSBuildThisFileDirectory)stylecop.json')" Text="Missing StyleCop.Json file!"/>
     </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,12 +16,8 @@
 
         This has NO use on C/C++ builds, and in fact NuGet is screwed up if it is included such that it WON'T resolve entries
         in packages.config (It seems to think it's a PackageReferences project even though it most definitely is NOT!)
-
-        BUSTED: See - https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3916#issuecomment-2953557715
-        for now disabling it all up, future PR will figure out how to disable for automated builds as local with
-        latest VS+SDK is fine.
         -->
-        <!--<GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(UseStyleCop)' != 'false' AND '$(MSBuildProjectExtension)'!='.vcxproj'" />-->
+        <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(UseStyleCop)' != 'false' AND '$(MSBuildProjectExtension)'!='.vcxproj'" />
     </ItemGroup>
 
     <!--

--- a/src/LibLLVMNative.slnx
+++ b/src/LibLLVMNative.slnx
@@ -22,6 +22,7 @@
     <File Path="../Llvm-Libs.targets" />
     <File Path="../NuGet.Config" />
     <File Path="../ReadMe.md" />
+    <File Path="../stylecop.json" />
     <File Path="LibLLVM/LlvmApplication.props" />
   </Folder>
   <Folder Name="/Solution Items/GitHub/" Id="f12d85e1-a53b-41ab-8cf6-be97599bd6d1" />

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings":
+  {
+        "indentation":
+        {
+            "indentationSize": 4,
+            "tabSize": 4,
+            "useTabs": false
+        },
+        "namingRules":
+        {
+            "allowCommonHungarianPrefixes": false,
+            "allowedHungarianPrefixes": ["h", "di", "op", "os", "ir", "is", "do", "un", "on", "to", "if", "no", "v", "in", "p", "ci"]
+        },
+        "orderingRules":
+        {
+            "elementOrder": [ "constant", "accessibility", "static", "readonly" ],
+            "systemUsingDirectivesFirst": true,
+            "usingDirectivesPlacement": "outsideNamespace",
+            "blankLinesBetweenUsingGroups": "allow"
+        },
+        "maintainabilityRules":
+        {
+            "topLevelTypes": ["class"]
+        },
+        "layoutRules":
+        {
+            "newlineAtEndOfFile": "require",
+            "allowConsecutiveUsings": true
+        },
+        "documentationRules":
+        {
+            "companyName": "Ubiquity.NET Contributors",
+            "headerDecoration": "-----------------------------------------------------------------------",
+            "documentExposedElements": true,
+            "documentInterfaces": false,
+            "documentInternalElements": false,
+            "documentPrivateElements": false,
+            "documentPrivateFields": false,
+            "documentationCulture":"en-us"
+        },
+        "readabilityRules":
+        {
+            "allowBuiltInTypeAliases": true
+        }
+  }
+}


### PR DESCRIPTION
Restored support for StyleCop
* StyleCop.Json was excluded from old `.gitignore`
    - Style cop wasn't used in this repo in previous releases as it was all native code so that was not noticed.
    - It was also disabled since it is in perpetual preview mode.
* Updated `.gitignore` to allow StyleCop.json
* Added error check in `Directory.Build.props`  to catch and report missing file with a more informative message than a spew of compiler fails.
    - See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3902
* StyleCop.json now included