### PR TITLE
Re-synch common build infrastructure

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - develop
-      - llvm_20
 
     paths-ignore:
       - '**.md'
@@ -20,7 +19,6 @@ on:
   pull_request:
     branches:
       - develop
-      - llvm_20
 
     paths-ignore:
       - '**.md'

--- a/OneFlow/ReadMe.md
+++ b/OneFlow/ReadMe.md
@@ -1,7 +1,7 @@
 # GIT OneFlow support scripts
 The scripts in this folder are used for release and feature branch management.
 This repository follows the [OneFlow](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow#develop-finishing-a-release-branch)
-model and workflow. With one active long term branch 'develop'. The master
+model and work-flow. With one active long term branch 'develop'. The master
 branch is present and long term but is not active, it only points to the latest
 official release (including preview releases) of the project. This is a convenience
 to allow getting the latests released source quickly. Generally the scripts used here

--- a/PsModules/CommonBuild/CommonBuild.pssproj
+++ b/PsModules/CommonBuild/CommonBuild.pssproj
@@ -59,6 +59,7 @@
   <Target Name="VSTest" Condition="'$(IsTestProject)'!='true'">
       <Message Importance="normal" Text="$(MSBuildProjectName) is not a test project; skipping test"/>
   </Target>
+  <Target Name="Rebuild"/>
   <!-- prevents NU1503 -->
   <Target Name="_IsProjectRestoreSupported"
           Returns="@(_ValidProjectsForRestore)">

--- a/PsModules/CommonBuild/Debug-Module.ps1
+++ b/PsModules/CommonBuild/Debug-Module.ps1
@@ -1,5 +1,5 @@
 # This script is used for debugging the module when using the
-# [Powershell Tools for VisualStudio 2022](https://marketplace.visualstudio.com/items?itemName=AdamRDriscoll.PowerShellToolsVS2022)
+# [PowerShell Tools for VisualStudio 2022](https://marketplace.visualstudio.com/items?itemName=AdamRDriscoll.PowerShellToolsVS2022)
 # It is MOST useful for computing and reporting the set of functions to export from this module for the PSD1 file.
 Import-Module $PSScriptRoot\CommonBuild.psd1 -Force -Verbose
 CommonBuild\Get-FunctionsToExport

--- a/PsModules/CommonBuild/Private/Get-VsArchitecture.ps1
+++ b/PsModules/CommonBuild/Private/Get-VsArchitecture.ps1
@@ -6,6 +6,6 @@ function Get-VsArchitecture()
         X64 {'x64'}
         Arm {'ARM'}
         Arm64 {'ARM64'}
-        default { throw 'Usupported runtime architecture for MSVC'}
+        default { throw 'Unsupported runtime architecture for MSVC'}
     }
 }

--- a/PsModules/CommonBuild/Public/ClassLike_CMakeConfig.ps1
+++ b/PsModules/CommonBuild/Public/ClassLike_CMakeConfig.ps1
@@ -1,5 +1,5 @@
 <#
-There are are just too many issues and edges that don't work well or at all with
+There are just too many issues and edges that don't work well or at all with
 PS classes and modules. So this fakes a class like we used to do in the "Good ol' days"
 with "C" before any of the modern OO languages were created.
 
@@ -8,7 +8,7 @@ A CMakeConfig is a hash table with the following properties
 |-------------------|-----------|------------|
 | Name              | string    | Name of the configuration |
 | ConfigurationType | string    | Build configuration of the CMAKE build |
-| BuildRoot         | string    | Root directory of the Build (Exctracted from a standard BuildInfo hash table) |
+| BuildRoot         | string    | Root directory of the Build (Extracted from a standard BuildInfo hash table) |
 | SrcRoot           | string    | Root directory of the CMAKE specific build |
 | Generator         | string    | Generator to use for this CMAKE build |
 | CMakeCommandArgs  | ArrayList | Custom args for the CMAKE command |
@@ -95,26 +95,6 @@ function New-CMakeConfig($name, [string]$buildConfiguration, [hashtable]$buildIn
     {
         $self['CMakeBuildVariables']['CMAKE_BUILD_TYPE']=$self['ConfigurationType']
     }
-
-    # Not needed with Ninja builds
-    #if($IsWindows)
-    #{
-    #    # running on ARM64 is not tested or supported
-    #    # This might not be needed now that the build is auto configuring the "VCVARS"
-    #    # Ninja build might also remove the need for this...
-    #    if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq "X64" )
-    #    {
-    #        $self['CMakeCommandArgs'].Add('-Thost=x64') | Out-Null
-    #        $self['InheritEnvironments'].Add('msvc_x64_x64') | Out-Null
-    #    }
-    #    else
-    #    {
-    #        $self['InheritEnvironments'].Add('msvc_x64') | Out-Null
-    #    }
-    #
-    #    # pass the /m switch to MSBUILD to enable parallel builds on all available CPU cores
-    #    $self['BuildCommandArgs'].Add('/m') | Out-Null
-    #}
 
     Assert-IsCMakeConfig $self
     return $self

--- a/PsModules/CommonBuild/Public/Invoke-External.ps1
+++ b/PsModules/CommonBuild/Public/Invoke-External.ps1
@@ -13,7 +13,7 @@ function Invoke-External($cmd)
     This provides two core features:
     1) Platform neutral execution of an external command that might conflict with a built-in alias.
     2) Detection of success for an external command (as a non-zero return code) and throws an exception
-        - This is the normal behaviour for command line applications. If the app returns a non-zero value
+        - This is the normal behavior for command line applications. If the app returns a non-zero value
           as a success code, then this script may not be used as it would consider that a failure.
 #>
     $cmdPath = $cmd

--- a/PsModules/CommonBuild/Public/Show-FullBuildInfo.ps1
+++ b/PsModules/CommonBuild/Public/Show-FullBuildInfo.ps1
@@ -9,7 +9,7 @@ function Show-FullBuildInfo
     properties so that the full details are available in logs.
 
 .DESCRIPTION
-    This function displays all the properties of the buildinfo to the information stream. Additionally,
+    This function displays all the properties of the build info to the information stream. Additionally,
     details of the current PATH, the .NET SDKs and runtimes installed is logged to the Verbose stream.
 #>
     Param($buildInfo)
@@ -19,6 +19,8 @@ function Show-FullBuildInfo
 
     Write-Information "BuildKind: $($buildInfo['CurrentBuildKind'])"
     Write-Information "CiBuildName: $env:CiBuildName"
+    Write-Information "env: Is*"
+    Write-Information (dir env:Is* | Format-Table -Property Name, value | Out-String)
 
     # This sort of detail is really only needed when solving problems with a runner
     Write-Verbose 'PATH:'

--- a/PsModules/RepoBuild/RepoBuild.psm1
+++ b/PsModules/RepoBuild/RepoBuild.psm1
@@ -26,7 +26,7 @@ function Get-ExportedFunctionNames
             }
             else
             {
-                Write-Information "found non-standard function mame '$name' in '$script'"
+                Write-Information "found non-standard function name '$name' in '$script'"
             }
         }
     }
@@ -34,7 +34,7 @@ function Get-ExportedFunctionNames
     return $retVal
 }
 
-# Exported from the module but NOT from the PSD1 list. Instead, you should use module qualifed name
+# Exported from the module but NOT from the PSD1 list. Instead, you should use module qualified name
 # to access this function. It is only useful when updating the set of public functions exported
 # to generate the required 'FunctionsToExport' property of the PSD1 file.
 function Get-FunctionsToExport

--- a/PsModules/RepoBuild/RepoBuild.pssproj
+++ b/PsModules/RepoBuild/RepoBuild.pssproj
@@ -52,5 +52,15 @@
     <Folder Include="Private\" />
     <Folder Include="Public\" />
   </ItemGroup>
+  <!-- prevents NU1503 -->
+  <Target Name="_IsProjectRestoreSupported" Returns="@(_ValidProjectsForRestore)">
+    <ItemGroup>
+      <_ValidProjectsForRestore Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
+  </Target>
+  <Target Name="VSTest" />
+  <Target Name="Restore" />
+  <Target Name="Build" />
+  <Target Name="Rebuild" />
   <Import Project="$(MSBuildExtensionsPath)\PowerShell Tools for Visual Studio\PowerShellTools.targets" Condition="Exists('$(MSBuildExtensionsPath)\PowerShell Tools for Visual Studio\PowerShellTools.targets')" />
 </Project>


### PR DESCRIPTION
Re-synch common build infrastructure
* Removed now defunct branch name `llvm20` from `pr-build.yml`
* Added sanity check before finalizing release
* Added updates to release tracking branch to `Publish-Release.ps1`
* Corrected typos in error messages and comments
* Removed commented out dead code
* Updated projects to contain targets that allow use in various build scenarios
    - Turns those scenarios into a NOP instead of an error