### PR TITLE
Minor Updates and corrections

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -76,9 +76,9 @@ jobs:
 
       - name: Publish packages to NuGet.org
         run: |
-          if( [string]::IsNullOrWhitesapce())
+          if( [string]::IsNullOrWhitesapce('${{ secrets.NUGETPUSH_ACCESS_TOKEN }}'))
           {
-              throw "NUGETPUSH_ACCESS_TOKEN" does not exist"
+              throw "'NUGETPUSH_ACCESS_TOKEN' does not exist"
           }
           $response = Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/" -Headers @{ Authorization = "Bearer ${{ secrets.NUGETPUSH_ACCESS_TOKEN }}" }
           if ($response.StatusCode -ne 200)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,6 +62,9 @@
                 -->
                 <ImplicitUsings>disable</ImplicitUsings>
                 <!-- NOTE: Top-Level statements blocked as an error in .editorconfig and ImplicitUsings 'feature' VERIFIED in the targets file -->
+
+                <!-- OPT-OUT of rude breaking change that alters the version numbering -->
+                <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
             </PropertyGroup>
             <ItemGroup Condition="'$(NoCommonAnalyzers)'!='true'">
                 <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />

--- a/src/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.cs
+++ b/src/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.cs
@@ -184,7 +184,7 @@ if(NeedsAlias){
             this.Write(@"( handle );
             return true;
 
-            // Native ABI declaration without ANY marshalling, AOT compatible
+            // Native ABI declaration without ANY marshaling, AOT compatible
             [DllImport( NativeMethods.LibraryName )]
             [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
             static unsafe extern void ");

--- a/src/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.tt
+++ b/src/LlvmBindingsGenerator/Templates/T4/GlobalHandleTemplate.tt
@@ -66,7 +66,7 @@ namespace Ubiquity.NET.Llvm.Interop
             <#=HandleDisposeFunction#>( handle );
             return true;
 
-            // Native ABI declaration without ANY marshalling, AOT compatible
+            // Native ABI declaration without ANY marshaling, AOT compatible
             [DllImport( NativeMethods.LibraryName )]
             [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
             static unsafe extern void <#=HandleDisposeFunction#>( nint p );


### PR DESCRIPTION
Minor Updates and corrections
* Updated release action to remove whitespace for clarity
* Updated typos in Global Handle templates
* Updated top opt-out of .NET breaking changed that forced it.
    - This is a bad design on the part of the .NET team, they should have used an opt-in pattern.