### PR TITLE
Report Full Build number as a string via API

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <!--
+  <!--
     Global references are included in ALL projects in this repository EXCEPT for VCXPROJ FILES.
     VCXPROJ uses the old style Packages.Config... (and that ain't changin' anytime soon apparently...
     [read - never gonna happen])
     -->
-    <ItemGroup>
-        <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.3" Condition="'$(MSBuildProjectExtension)' != '.vcxproj'"/>
-        <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" Condition="'$(NoCommonAnalyzers)' != 'true'" />
-        <GlobalPackageReference Include="IDisposableAnalyzers" Version="4.0.8" Condition="'$(NoCommonAnalyzers)' != 'true'" />
-        <GlobalPackageReference Include="MustUseRetVal" Condition="'$(NoCommonAnalyzers)' != 'true'" Version="0.0.2"/>
-        <!--
+  <ItemGroup>
+    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.5-alpha" Condition="'$(MSBuildProjectExtension)' != '.vcxproj'" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" Condition="'$(NoCommonAnalyzers)' != 'true'" />
+    <GlobalPackageReference Include="IDisposableAnalyzers" Version="4.0.8" Condition="'$(NoCommonAnalyzers)' != 'true'" />
+    <GlobalPackageReference Include="MustUseRetVal" Condition="'$(NoCommonAnalyzers)' != 'true'" Version="0.0.2" />
+    <!--
         NOTE: This analyzer is sadly, perpetually in "pre-release mode". There have been many issues/discussion on the point
         and it has all fallen on deaf ears. So policies regarding "NO-Prerelease" components need to be overruled on this one.
 
         This has NO use on C/C++ builds, and in fact NuGet is screwed up if it is included such that it WON'T resolve entries
         in packages.config (It seems to think it's a PackageReferences project even though it most definitely is NOT!)
         -->
-        <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(UseStyleCop)' != 'false' AND '$(MSBuildProjectExtension)'!='.vcxproj'" />
-    </ItemGroup>
-
-    <!--
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(UseStyleCop)' != 'false' AND '$(MSBuildProjectExtension)'!='.vcxproj'" />
+  </ItemGroup>
+  <!--
     Package versions made consistent across all packages referenced in this repository
     -->
-    <ItemGroup>
-        <PackageVersion Include="System.IO.Hashing" Version="9.0.3" />
-        <PackageVersion Include="System.CodeDom" Version="9.0.2" />
-        <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
-
-        <PackageVersion Include="CppSharp" Version="1.1.5.3168" />
-        <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-        <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.3" />
+    <PackageVersion Include="System.CodeDom" Version="9.0.7" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="CppSharp" Version="1.1.5.3168" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="CommandLineParser" Version="2.9.1" />
+  </ItemGroup>
 </Project>

--- a/src/LibLLVM/CSemVer.h
+++ b/src/LibLLVM/CSemVer.h
@@ -42,6 +42,8 @@ namespace LibLLVM
 
     // CI Builds use an ODD numbered file version, but the ordered version number ignores CI and meta data information for ordering
     constexpr uint64_t OrderedVersion = FileVersion64 >> 1;
+
+    constexpr std::string_view FullBuildNumber = FULL_BUILD_NUMBER_STRING;
 }
 
 #endif

--- a/src/LibLLVM/LibLLVM.vcxproj
+++ b/src/LibLLVM/LibLLVM.vcxproj
@@ -9,7 +9,7 @@
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">win-x64</RuntimeIdentifier>
     <!-- TODO: Support SourceLink [See: https://github.com/dotnet/sourcelink#using-source-link-in-c-projects]-->
   </PropertyGroup>
-  <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.props" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.props')" />
+  <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.props" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.props')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Release|x64">
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.targets" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" />
+    <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.targets" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -104,15 +104,26 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\llvm-libs.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Message Importance="High" Text="PlatformConfiguration: $(Platform)|$(Configuration)" />
-    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.props'))" />
-    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.4\build\Ubiquity.NET.Versioning.Build.Tasks.targets'))" />
+    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.props'))" />
+    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.5-alpha\build\Ubiquity.NET.Versioning.Build.Tasks.targets'))" />
   </Target>
   <Target Name="AlwaysShowBuildParams" AfterTargets="ShowBuildParams">
     <Message Importance="High" Text="FullBuildNumber: $(FullBuildNumber)" />
     <Message Importance="High" Text=" PackageVersion: $(PackageVersion)" />
     <Message Importance="High" Text="    FileVersion: $(FileVersion)" />
+  </Target>
+  <!--
+  Appends Full build number to include header for native code.
+  Until https://github.com/UbiquityDotNET/CSemVer.GitBuild/issues/69 is implemented
+  this custom target is required here.
+  -->
+  <Target Name="AppendVesionInfoHeader" AfterTargets="GenerateVesionInfoHeader">
+    <ItemGroup>
+      <_FullVersionLine Include='#define FULL_BUILD_NUMBER_STRING "$(FullBuildNumber)"'/>
+    </ItemGroup>
+    <WriteLinesToFile File="$(IntermediateOutputPath)$(GeneratedVersionInfoHeader)" Lines="@(_FullVersionLine)" />
   </Target>
 </Project>

--- a/src/LibLLVM/TargetRegistrationBindings.cpp
+++ b/src/LibLLVM/TargetRegistrationBindings.cpp
@@ -1244,8 +1244,9 @@ extern "C"
         return nullptr;
     }
 
-    uint64_t LibLLVMGetVersion()
+    char const* LibLLVMGetVersion(size_t* len)
     {
-        return LibLLVM::FileVersion64;
+        *len = LibLLVM::FullBuildNumber.size();
+        return LibLLVM::FullBuildNumber.data();
     }
 }

--- a/src/LibLLVM/include/libllvm-c/TargetRegistrationBindings.h
+++ b/src/LibLLVM/include/libllvm-c/TargetRegistrationBindings.h
@@ -57,8 +57,9 @@ LLVMErrorRef LibLLVMRegisterTarget(LibLLVMCodeGenTarget target, LibLLVMTargetReg
 int32_t LibLLVMGetNumTargets();
 LLVMErrorRef LibLLVMGetRuntimeTargets(LibLLVMCodeGenTarget* targetArray, int32_t lengthOfArray);
 
-// Return is the version info for this library
-uint64_t LibLLVMGetVersion();
+// Return is the version info for this library as a string (CSemVer/CSemVer-CI)
+// Version string is a constant so there is no need to release it for marshaling.
+char const* LibLLVMGetVersion(size_t* len);
 
 LLVM_C_EXTERN_C_END
 #endif

--- a/src/LibLLVM/packages.config
+++ b/src/LibLLVM/packages.config
@@ -6,5 +6,5 @@
   minimum ranges, it has to be exact... [Yet another reason to ditch VCXPROJ in favor of CMAKE
   and custom scripts.]
   -->
-  <package id="Ubiquity.NET.Versioning.Build.Tasks" version="5.0.4" targetFramework="native" />
+  <package id="Ubiquity.NET.Versioning.Build.Tasks" version="5.0.5-alpha" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Report Full Build number as a string via API
* Provide full CSemVer/CSemVer-CI string from API
    - This allows extraction of all the pre-release/CI data available
* Bumped version of versioning build task to account for known bug.
    - This depends on a pre-release version but it is pre-release itself.