### PR TITLE
Consistent use of `extern C` macros

### DIFF
--- a/src/LibLLVM/include/libllvm-c/AnalysisBindings.h
+++ b/src/LibLLVM/include/libllvm-c/AnalysisBindings.h
@@ -4,16 +4,11 @@
 #include <llvm-c/Core.h>
 #include <llvm-c/Analysis.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     LLVMBool LibLLVMVerifyFunctionEx( LLVMValueRef Fn
                                       , LLVMVerifierFailureAction Action
                                       , char** OutMessages
     );
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/AttributeBindings.h
+++ b/src/LibLLVM/include/libllvm-c/AttributeBindings.h
@@ -20,7 +20,6 @@
 #include <stdint.h>
 
 LLVM_C_EXTERN_C_BEGIN
-
     enum LibLLVMAttributeArgKind
     {
         LibLLVMAttributeArgKind_None,

--- a/src/LibLLVM/include/libllvm-c/ContextBindings.h
+++ b/src/LibLLVM/include/libllvm-c/ContextBindings.h
@@ -3,15 +3,9 @@
 
 #include "llvm-c/Core.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     LLVMBool LibLLVMContextGetIsODRUniquingDebugTypes( LLVMContextRef context );
     void LibLLVMContextSetIsODRUniquingDebugTypes( LLVMContextRef context, LLVMBool state );
-
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/IRBindings.h
+++ b/src/LibLLVM/include/libllvm-c/IRBindings.h
@@ -17,20 +17,8 @@
 #include <llvm-c/Core.h>
 #include <llvm-c/ExecutionEngine.h>
 
-#ifdef __cplusplus
-#include <llvm/IR/Metadata.h>
-#include <llvm/Support/CBindingWrapping.h>
-#endif
-
-#include <stdint.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     LLVMBool LibLLVMHasUnwindDest( LLVMValueRef Invoke );
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/MetadataBindings.h
+++ b/src/LibLLVM/include/libllvm-c/MetadataBindings.h
@@ -5,10 +5,7 @@
 #include "llvm-c/Core.h"
 #include "llvm-c/DebugInfo.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     typedef enum LibLLVMDwarfTag
     {
 #define HANDLE_DW_TAG(ID, NAME, VERSION, VENDOR, KIND) \
@@ -94,8 +91,6 @@ extern "C" {
     LLVMBool LibLLVMIsDistinct( LLVMMetadataRef M );
 
     int64_t LibLLVMDISubRangeGetLowerBounds( LLVMMetadataRef /*DISubRange*/ sr, int64_t defaultLowerBound );
-#ifdef __cplusplus
-} // extern "C"
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/ModuleBindings.h
+++ b/src/LibLLVM/include/libllvm-c/ModuleBindings.h
@@ -4,9 +4,7 @@
 #include "llvm-c/Core.h"
 #include "llvm-c/Comdat.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+LLVM_C_EXTERN_C_BEGIN
     typedef struct LLVMOpaqueComdatIterator* LibLLVMComdatIteratorRef;
 
     uint32_t LibLLVMModuleGetNumComdats(LLVMModuleRef module);
@@ -34,8 +32,6 @@ extern "C" {
     // Alias enumeration
     LLVMValueRef LibLLVMModuleGetFirstGlobalAlias( LLVMModuleRef M );
     LLVMValueRef LibLLVMModuleGetNextGlobalAlias( LLVMValueRef /*GlobalAlias*/ valueRef );
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/ObjectFileBindings.h
+++ b/src/LibLLVM/include/libllvm-c/ObjectFileBindings.h
@@ -3,16 +3,10 @@
 
 #include "llvm-c/Object.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     LLVMSymbolIteratorRef LibLLVMSymbolIteratorClone( LLVMSymbolIteratorRef ref );
     LLVMSectionIteratorRef LibLLVMSectionIteratorClone( LLVMSectionIteratorRef ref );
     LLVMRelocationIteratorRef LibLLVMRelocationIteratorClone( LLVMRelocationIteratorRef ref );
-
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/OrcJITv2Bindings.h
+++ b/src/LibLLVM/include/libllvm-c/OrcJITv2Bindings.h
@@ -6,4 +6,5 @@
 LLVM_C_EXTERN_C_BEGIN
     LLVMErrorRef LibLLVMExecutionSessionRemoveDyLib(LLVMOrcExecutionSessionRef session, LLVMOrcJITDylibRef lib);
 LLVM_C_EXTERN_C_END
+
 #endif

--- a/src/LibLLVM/include/libllvm-c/PassBuilderOptionsBindings.h
+++ b/src/LibLLVM/include/libllvm-c/PassBuilderOptionsBindings.h
@@ -4,7 +4,6 @@
 #include "llvm-c/Transforms/PassBuilder.h"
 
 LLVM_C_EXTERN_C_BEGIN
-
     LLVMBool LibLLVMPassBuilderOptionsGetVerifyEach(LLVMPassBuilderOptionsRef Options);
     LLVMBool LibLLVMPassBuilderOptionsGetDebugLogging(LLVMPassBuilderOptionsRef Options);
     // result is a simple alias; DO NOT dispose of it in any way.
@@ -19,7 +18,6 @@ LLVM_C_EXTERN_C_BEGIN
     LLVMBool LibLLVMPassBuilderOptionsGetCallGraphProfile(LLVMPassBuilderOptionsRef Options);
     LLVMBool LibLLVMPassBuilderOptionsGetMergeFunctions(LLVMPassBuilderOptionsRef Options);
     int32_t LibLLVMPassBuilderOptionsGetInlinerThreshold(LLVMPassBuilderOptionsRef Options);
-
 LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/TargetMachineBindings.h
+++ b/src/LibLLVM/include/libllvm-c/TargetMachineBindings.h
@@ -4,19 +4,18 @@
 #include <llvm-c/TargetMachine.h>
 
 LLVM_C_EXTERN_C_BEGIN
+    LLVMBool LibLLVMGetTargetMachineAsmVerbosity(LLVMTargetMachineRef tm);
+    LLVMBool LibLLVMGetTargetMachineFastISel(LLVMTargetMachineRef tm);
+    LLVMBool LibLLVMGetTargetMachineGlobalISel(LLVMTargetMachineRef T);
+    LLVMGlobalISelAbortMode LibLLVMGetTargetMachineGlobalISelAbort(LLVMTargetMachineRef tm);
+    LLVMBool LibLLVMGetTargetMachineMachineOutliner(LLVMTargetMachineRef tm);
 
-LLVMBool LibLLVMGetTargetMachineAsmVerbosity(LLVMTargetMachineRef tm);
-LLVMBool LibLLVMGetTargetMachineFastISel(LLVMTargetMachineRef tm);
-LLVMBool LibLLVMGetTargetMachineGlobalISel(LLVMTargetMachineRef T);
-LLVMGlobalISelAbortMode LibLLVMGetTargetMachineGlobalISelAbort(LLVMTargetMachineRef tm);
-LLVMBool LibLLVMGetTargetMachineMachineOutliner(LLVMTargetMachineRef tm);
-
-char const* LibLLVMTargetMachineOptionsGetCPU(LLVMTargetMachineOptionsRef Options, size_t* len);
-char const* LibLLVMTargetMachineOptionsGetFeatures(LLVMTargetMachineOptionsRef Options, size_t* len);
-char const* LibLLVMTargetMachineOptionsGetABI(LLVMTargetMachineOptionsRef Options, size_t*len);
-LLVMCodeGenOptLevel LibLLVMTargetMachineOptionsGetCodeGenOptLevel(LLVMTargetMachineOptionsRef Options);
-LLVMRelocMode LibLLVMTargetMachineOptionsGetRelocMode(LLVMTargetMachineOptionsRef Options);
-LLVMCodeModel LibLLVMTargetMachineOptionsGetCodeModel(LLVMTargetMachineOptionsRef Options);
-
+    char const* LibLLVMTargetMachineOptionsGetCPU(LLVMTargetMachineOptionsRef Options, size_t* len);
+    char const* LibLLVMTargetMachineOptionsGetFeatures(LLVMTargetMachineOptionsRef Options, size_t* len);
+    char const* LibLLVMTargetMachineOptionsGetABI(LLVMTargetMachineOptionsRef Options, size_t*len);
+    LLVMCodeGenOptLevel LibLLVMTargetMachineOptionsGetCodeGenOptLevel(LLVMTargetMachineOptionsRef Options);
+    LLVMRelocMode LibLLVMTargetMachineOptionsGetRelocMode(LLVMTargetMachineOptionsRef Options);
+    LLVMCodeModel LibLLVMTargetMachineOptionsGetCodeModel(LLVMTargetMachineOptionsRef Options);
 LLVM_C_EXTERN_C_END
+
 #endif

--- a/src/LibLLVM/include/libllvm-c/TargetRegistrationBindings.h
+++ b/src/LibLLVM/include/libllvm-c/TargetRegistrationBindings.h
@@ -7,59 +7,58 @@
 #include <llvm-c/Error.h>
 
 LLVM_C_EXTERN_C_BEGIN
+    // This needs to provide a single target neutral registration that handles the native target AND one additional CPU
+    // in a target independent stable API.
 
-// This needs to provide a single target neutral registration that handles the native target AND one additional CPU
-// in a target independent stable API.
+    enum LibLLVMCodeGenTarget
+    {
+        CodeGenTarget_None = 0,    // Invalid value
+        CodeGenTarget_Native,      // Generic value for the native architecture of the current runtime (generally used for local JIT execution)
+        CodeGenTarget_AArch64,     // ARM 64 bit Architecture
+        CodeGenTarget_AMDGPU,      // AMD GPUs
+        CodeGenTarget_ARM,         // ARM 32 bit (including thumb mode)
+        CodeGenTarget_AVR,         // Atmel AVR Micro controller
+        CodeGenTarget_BPF,         // Berkeley Packet Filter (Including eBPF)
+        CodeGenTarget_Hexagon,     // Qualcom Hexagon DSP/NPU family
+        CodeGenTarget_Lanai,       // Un[der]documented Google (Myricom) processor (see: https://q3k.org/lanai.html)
+        CodeGenTarget_LoongArch,   // Loongson Custom ISA CPU (see: https://en.wikipedia.org/wiki/Loongson)
+        CodeGenTarget_MIPS,        // MIPS based CPU
+        CodeGenTarget_MSP430,      // TI MSP430 Mixed-signal microcontroller
+        CodeGenTarget_NVPTX,       // Nvidia Parallel Thread Execution (Nvidia GPUs)
+        CodeGenTarget_PowerPC,     // Apple/IBM/Motorola CPU
+        CodeGenTarget_RISCV,       // Open Source RISC Architecture
+        CodeGenTarget_Sparc,       // Sun Microsystems SPARC CPU
+        CodeGenTarget_SPIRV,       // Standard Portable Intermediate Representation (see: https://en.wikipedia.org/wiki/Standard_Portable_Intermediate_Representation)
+        CodeGenTarget_SystemZ,     // z/Architecture (IBM 64 bit CISC) (see: https://en.wikipedia.org/wiki/Z/Architecture)
+        CodeGenTarget_VE,          // NEC's Vector Engine
+        CodeGenTarget_WebAssembly, // Browser interpreted/JIT execution
+        CodeGenTarget_X86,         // Intel X86 and AMD64
+        CodeGenTarget_XCore,       // XMOS core (see: https://en.wikipedia.org/wiki/XMOS)
+        CodeGenTarget_All = INT_MAX
+    };
 
-enum LibLLVMCodeGenTarget
-{
-    CodeGenTarget_None = 0,    // Invalid value
-    CodeGenTarget_Native,      // Generic value for the native architecture of the current runtime (generally used for local JIT execution)
-    CodeGenTarget_AArch64,     // ARM 64 bit Architecture
-    CodeGenTarget_AMDGPU,      // AMD GPUs
-    CodeGenTarget_ARM,         // ARM 32 bit (including thumb mode)
-    CodeGenTarget_AVR,         // Atmel AVR Micro controller
-    CodeGenTarget_BPF,         // Berkeley Packet Filter (Including eBPF)
-    CodeGenTarget_Hexagon,     // Qualcom Hexagon DSP/NPU family
-    CodeGenTarget_Lanai,       // Un[der]documented Google (Myricom) processor (see: https://q3k.org/lanai.html)
-    CodeGenTarget_LoongArch,   // Loongson Custom ISA CPU (see: https://en.wikipedia.org/wiki/Loongson)
-    CodeGenTarget_MIPS,        // MIPS based CPU
-    CodeGenTarget_MSP430,      // TI MSP430 Mixed-signal microcontroller
-    CodeGenTarget_NVPTX,       // Nvidia Parallel Thread Execution (Nvidia GPUs)
-    CodeGenTarget_PowerPC,     // Apple/IBM/Motorola CPU
-    CodeGenTarget_RISCV,       // Open Source RISC Architecture
-    CodeGenTarget_Sparc,       // Sun Microsystems SPARC CPU
-    CodeGenTarget_SPIRV,       // Standard Portable Intermediate Representation (see: https://en.wikipedia.org/wiki/Standard_Portable_Intermediate_Representation)
-    CodeGenTarget_SystemZ,     // z/Architecture (IBM 64 bit CISC) (see: https://en.wikipedia.org/wiki/Z/Architecture)
-    CodeGenTarget_VE,          // NEC's Vector Engine
-    CodeGenTarget_WebAssembly, // Browser interpreted/JIT execution
-    CodeGenTarget_X86,         // Intel X86 and AMD64
-    CodeGenTarget_XCore,       // XMOS core (see: https://en.wikipedia.org/wiki/XMOS)
-    CodeGenTarget_All = INT_MAX
-};
+    // This is a "FLAGS" enum
+    enum LibLLVMTargetRegistrationKind
+    {
+        TargetRegistration_None = 0x00,
+        TargetRegistration_Target = 0x01,
+        TargetRegistration_TargetInfo = 0x02,
+        TargetRegistration_TargetMachine = 0x04,
+        TargetRegistration_AsmPrinter = 0x08,
+        TargetRegistration_Disassembler = 0x10,
+        TargetRegistration_AsmParser = 0x20,
+        TargetRegistration_CodeGenRegistration = TargetRegistration_Target | TargetRegistration_TargetInfo | TargetRegistration_TargetMachine,
+        TargetRegistration_All = TargetRegistration_CodeGenRegistration | TargetRegistration_AsmPrinter | TargetRegistration_Disassembler | TargetRegistration_AsmParser
+    };
 
-// This is a "FLAGS" enum
-enum LibLLVMTargetRegistrationKind
-{
-    TargetRegistration_None = 0x00,
-    TargetRegistration_Target = 0x01,
-    TargetRegistration_TargetInfo = 0x02,
-    TargetRegistration_TargetMachine = 0x04,
-    TargetRegistration_AsmPrinter = 0x08,
-    TargetRegistration_Disassembler = 0x10,
-    TargetRegistration_AsmParser = 0x20,
-    TargetRegistration_CodeGenRegistration = TargetRegistration_Target | TargetRegistration_TargetInfo | TargetRegistration_TargetMachine,
-    TargetRegistration_All = TargetRegistration_CodeGenRegistration | TargetRegistration_AsmPrinter | TargetRegistration_Disassembler | TargetRegistration_AsmParser
-};
+    // NOTE: registrations is not value checked. ONLY valid bits are tested and additional bits are ignored (NOP)
+    LLVMErrorRef LibLLVMRegisterTarget(LibLLVMCodeGenTarget target, LibLLVMTargetRegistrationKind registrations);
+    int32_t LibLLVMGetNumTargets();
+    LLVMErrorRef LibLLVMGetRuntimeTargets(LibLLVMCodeGenTarget* targetArray, int32_t lengthOfArray);
 
-// NOTE: registrations is not value checked. ONLY valid bits are tested and additional bits are ignored (NOP)
-LLVMErrorRef LibLLVMRegisterTarget(LibLLVMCodeGenTarget target, LibLLVMTargetRegistrationKind registrations);
-int32_t LibLLVMGetNumTargets();
-LLVMErrorRef LibLLVMGetRuntimeTargets(LibLLVMCodeGenTarget* targetArray, int32_t lengthOfArray);
-
-// Return is the version info for this library as a string (CSemVer/CSemVer-CI)
-// Version string is a constant so there is no need to release it for marshaling.
-char const* LibLLVMGetVersion(size_t* len);
-
+    // Return is the version info for this library as a string (CSemVer/CSemVer-CI)
+    // Version string is a constant so there is no need to release it for marshaling.
+    char const* LibLLVMGetVersion(size_t* len);
 LLVM_C_EXTERN_C_END
+
 #endif

--- a/src/LibLLVM/include/libllvm-c/TripleBindings.h
+++ b/src/LibLLVM/include/libllvm-c/TripleBindings.h
@@ -2,10 +2,7 @@
 #define LLVM_TRIPLE_BINDINGS_H
 #include <llvm-c\Types.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     enum LibLLVMTripleArchType
     {
         UnknownArch,
@@ -315,8 +312,6 @@ extern "C" {
     char const* LibLLVMTripleGetVendorTypeName( LibLLVMTripleVendorType vendor );
     char const* LibLLVMTripleGetOsTypeName( LibLLVMTripleOSType osType );
     char const* LibLLVMTripleGetEnvironmentTypeName( LibLLVMTripleEnvironmentType environmentType );
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/ValueBindings.h
+++ b/src/LibLLVM/include/libllvm-c/ValueBindings.h
@@ -4,10 +4,7 @@
 #include "llvm-c/Core.h"
 #include "ModuleBindings.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+LLVM_C_EXTERN_C_BEGIN
     // ordering matters, all distinct values are generated first, then any derived values (e.g. foo = bar + 1), to ensure the
     // values match expectations of underlying C++ code and don't alter the sequencing as C++ numbers enum values without an
     // initializer as automatic +1 of the previous value, thus sticking the derived values in at arbitrary locations in the
@@ -82,8 +79,6 @@ extern "C" {
     // then LLVMGetFirstDbgRecord() will crash from a null pointer dereference. So,
     // this function is used to detect such a case before iterating the records.
     LLVMBool LibLLVMHasDbgRecords(LLVMValueRef i);
-#ifdef __cplusplus
-}
-#endif
+LLVM_C_EXTERN_C_END
 
 #endif


### PR DESCRIPTION
Consistent use of `extern C` macros
*Applied `LLVM_C_EXTERN_C_BEGIN/LLVM_C_EXTERN_C_END` consistently throughout extended APIs
* Removed some unused header includes.