### PR TITLE
Allow consumers of NuGet to target LTSC

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,8 +2,8 @@ name: CI-Build
 permissions:
   contents: read
 defaults:
-    run:
-        shell: pwsh
+  run:
+    shell: pwsh
 
 on:
   push:
@@ -12,10 +12,9 @@ on:
 
     paths-ignore:
       - '**.md'
+      - '.github/workflows/release-build.yml'
+      - 'OneFlow/*.*'
       - '**.dic'
-      - 'BuildVersion.xml'
-      - 'GitHub/workflows/release-build.yml'
-      - 'OneFlow/**.ps1'
 
   pull_request:
     branches:
@@ -23,10 +22,9 @@ on:
 
     paths-ignore:
       - '**.md'
+      - '.github/workflows/release-build.yml'
+      - 'OneFlow/*.*'
       - '**.dic'
-      - 'BuildVersion.xml'
-      - 'GitHub/workflows/release-build.yml'
-      - 'OneFlow/**.ps1'
 
 jobs:
   build_target:
@@ -35,11 +33,11 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-           persist-credentials: false
-           fetch-depth: 0
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Build Source
-        run: ./Build-All.ps1 -ForceClean
+        run: .\Build-LibLLVMAndPackage.ps1 -FullInit
 
       - name: Upload build logs
         if: always() && github.event_name == 'pull_request'

--- a/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.csproj
+++ b/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.csproj
@@ -3,10 +3,10 @@ Project to build the NUGET Meta package
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <!--
-    To support a meta pacakge where the referenced packages may not exist at build time this must use a NUSPEC file directly.
+    To support a meta package where the referenced packages may not exist at build time this must use a NUSPEC file directly.
     The CSPROJ system for MSBUILD will try to restore referenced packages etc... and basically requires the ability to find
     the listed dependencies. (They won't exist yet for this build/repo)
     -->

--- a/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.nuspec
+++ b/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.nuspec
@@ -3,8 +3,8 @@
 INPUT:
     $packageID$ - ID of the package
     $version$ - Version of this package
-    $authors$ - Authors of the pacakge
-    $description$ - Description of the pacakge
+    $authors$ - Authors of the package
+    $description$ - Description of the package
     $tags$ - Tags to mark this package (Helps searching)
     $licExpression$ - License expression
     $projectUrl$ - URL for the project

--- a/src/Ubiquity.NET.Llvm.Interop.Handles/Ubiquity.NET.Llvm.Interop.Handles.csproj
+++ b/src/Ubiquity.NET.Llvm.Interop.Handles/Ubiquity.NET.Llvm.Interop.Handles.csproj
@@ -14,10 +14,10 @@ The generated code has the following requirements of the consumer:
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <!--
-    To support source code pacakge, this must use a NUSPEC file directly. The CSPROJ system
+    To support source code package, this must use a NUSPEC file directly. The CSPROJ system
     for MSBUILD does NOT support setting the "buildaction" for files in a package. It determines
     that on it's own based on the target location and provides no mechanism for overriding it.
     -->
@@ -32,7 +32,7 @@ The generated code has the following requirements of the consumer:
     <NoCommonAnalyzers>true</NoCommonAnalyzers>
 
     <Authors>LLVM.org,Ubiquity.NET</Authors>
-    <Description>Generated LLVM handle types for Ubiquity.NET.Llvm.Interop [$(LlvmVersion)]. Direct use of this package **STRONGLY** discouraged (You are on your own!), instead you should use the Ubiquity.NET.Llvm package, which provides a full C# object model projection of the LLVM APIs on top of this library.</Description>
+    <Description>Generated LLVM handle types for Ubiquity.NET.Llvm.Interop [$(LlvmVersion)]. Direct use of this package is **STRONGLY** discouraged (You are on your own!), instead you should use the Ubiquity.NET.Llvm package, which provides a full C# object model projection of the LLVM APIs on top of this library.</Description>
     <PackageTags>LLVM</PackageTags>
     <PackageProjectUrl>https://github.com/UbiquityDotNET/Llvm.NET</PackageProjectUrl>
     <RepositoryUrl>https://github.com/UbiquityDotNET/Llvm.NET.git</RepositoryUrl>

--- a/src/Ubiquity.NET.Llvm.Interop.Handles/Ubiquity.NET.Llvm.Interop.Handles.nuspec
+++ b/src/Ubiquity.NET.Llvm.Interop.Handles/Ubiquity.NET.Llvm.Interop.Handles.nuspec
@@ -27,11 +27,11 @@ INPUT:
     <files>
         <!--
         NOTE: Default NUGET build action is "Compile"; For reasons unknown there is NO way to
-              set that in a CSPROJ file. In a CSPROJ file ALL content is set to a buildaction
-              of "content" unless the target path is for runtime. (Guessing as I can't find
-              docs on the point). Ultimately, there is NO means to place "content" into the
-              contentFiles subfolder AND set it to compile. Thus a NUSPEC file is REQUIRED to
-              include source... [Sigh...]
+              set that in a CSPROJ file. In a CSPROJ file ALL content is set to a NuGet
+              `buildaction` of "content" unless the target path is for runtime. (Guessing as
+              I can't find docs on the point). Ultimately, there is NO means to place "content"
+              into the contentFiles sub-folder AND set it to compile. Thus a NUSPEC file is
+              REQUIRED to include source... [Sigh...]
         -->
         <file src="$GeneratedSourceRoot$**.cs" target="contentFiles/cs/$tfmGroup$/$packageID$/" />
     </files>


### PR DESCRIPTION
Updated support to allow targeting .NET 8.0 LTSC as minimum.
* There's nothing in the generated code that requires .NET 9.0
* Updated build action to match format across repos

Fixes #51