### PR TITLE
Enabled local debug builds

### DIFF
--- a/Build-LibLLVMAndPackage.ps1
+++ b/Build-LibLLVMAndPackage.ps1
@@ -27,6 +27,8 @@ Param(
     [switch]$SkipLLvm
 )
 
+Set-StrictMode -Version 3.0
+
 Push-location $PSScriptRoot
 
 $oldPath = $env:Path
@@ -65,14 +67,20 @@ try
         Write-Information "Post Build Size: $($preDeleteSize)Gb"
     }
 
-    # On Windows Build and run source generator as the generated exports.g.def is needed by the windows
-    # version of the DLL
+    # On Windows Build, run source generator to get the generated exports.g.def
     if ($IsWindows)
     {
+        #TODO: generalize this for ALL windows architectures (ARM64...)
+        # SEE: Llvm-Libs.props in the root of this repo for how this is specified for
+        # the C++ build.
+        $llvmPlatformConfig = "win-x64"
+
+        $llvmPlatformConfigRoot = Join-Path $buildInfo['BuildOutputPath'] $llvmPlatformConfig
         $extensionsRoot = Join-Path $buildInfo['SrcRootPath'] 'LibLLVM'
         $generatorOptions = @{
             LlvmRoot = $buildInfo['LlvmRoot']
             ExtensionsRoot = $extensionsRoot
+            ConfigPathRoot = $llvmPlatformConfigRoot
             ExportsDefFilePath = Join-Path $extensionsRoot 'exports.g.def'
         }
 

--- a/PsModules/RepoBuild/Public/Invoke-BindingsGenerator.ps1
+++ b/PsModules/RepoBuild/Public/Invoke-BindingsGenerator.ps1
@@ -5,12 +5,18 @@ function Invoke-BindingsGenerator([hashtable]$buildInfo , [hashtable]$Options)
         throw "Building/using the generator is not supported and not needed for non-Windows platforms"
     }
 
-    if(!$Options.ContainsKey('LlvmRoot') -or $Options['LlvmRoot'] -isnot [string])
+    if(!$Options.ContainsKey('LlvmRoot') -or ($Options['LlvmRoot'] -isnot [string]))
     {
         throw "Options value for required LlvmRoot is missing or invalid"
     }
 
-    if(!$Options.ContainsKey('ExtensionsRoot') -or $Options['ExtensionsRoot'] -isnot [string])
+    if(!$Options.ContainsKey('ConfigPathRoot') -or ($Options['ConfigPathRoot'] -isnot [string]))
+    {
+        Write-Error ($Options | Format-List | Out-String)
+        throw "Options value for required ConfigPathRoot is missing or invalid"
+    }
+
+    if(!$Options.ContainsKey('ExtensionsRoot') -or ($Options['ExtensionsRoot'] -isnot [string]))
     {
         throw "Options value for required ExtensionsRoot is missing or invalid"
     }
@@ -30,6 +36,7 @@ function Invoke-BindingsGenerator([hashtable]$buildInfo , [hashtable]$Options)
         $bindingsGenerator,
         '-l', $Options['LlvmRoot'],
         '-e', $Options['ExtensionsRoot']
+        '-i', $Options['ConfigPathRoot']
     )
 
     if ($Options.ContainsKey('ExportsDefFilePath'))

--- a/src/IgnoredWords.dic
+++ b/src/IgnoredWords.dic
@@ -67,6 +67,7 @@ Globalization
 Hashtable
 Identifier
 Impl
+initializer
 inline
 inlined
 Interop
@@ -95,10 +96,12 @@ paren
 perf
 pointee
 Pre
+preprocessor
 proj
 readonly
 refactor
 refcount
+referenceable
 repl
 repo
 RMW
@@ -107,6 +110,7 @@ RValue
 sizeof
 src
 Stateful
+stderr
 struct
 structs
 Subrange
@@ -127,6 +131,7 @@ uninstantiated
 uniqued
 uniqueing
 unmarshal
+untyped
 userdefinedop
 Users
 usings

--- a/src/LibLLVM/DataLayoutBindings.cpp
+++ b/src/LibLLVM/DataLayoutBindings.cpp
@@ -8,7 +8,7 @@ extern "C"
 {
     LLVMErrorRef LibLLVMParseDataLayout(char const* layoutString, size_t strLen, /*out*/ LLVMTargetDataRef* outRetVal)
     {
-        auto expectedResult = DataLayout::parse(StringRef(layoutString, strLen));
+        llvm::Expected<DataLayout> expectedResult = DataLayout::parse(StringRef(layoutString, strLen));
         *outRetVal = expectedResult ? wrap(new DataLayout(*expectedResult)) : nullptr;
         return expectedResult ? 0 : wrap(expectedResult.takeError());
     }

--- a/src/LibLLVM/LibLLVM.vcxproj
+++ b/src/LibLLVM/LibLLVM.vcxproj
@@ -9,9 +9,13 @@
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)'==''">win-x64</RuntimeIdentifier>
     <!-- TODO: Support SourceLink [See: https://github.com/dotnet/sourcelink#using-source-link-in-c-projects]-->
   </PropertyGroup>
-  <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.props" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.props')" />
+  <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.props" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.props')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -31,19 +35,31 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.targets" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" />
+    <Import Project="$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.targets" Condition="Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="$(MSBuildThisFileDirectory)..\..\llvm-libs.props" />
     <Import Project="LlvmApplication.props" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(MSBuildThisFileDirectory)..\..\llvm-libs.props" />
+    <Import Project="LlvmApplication.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
+    <TargetName>Ubiquity.NET.$(MSBuildProjectName)</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>Ubiquity.NET.$(MSBuildProjectName)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -53,9 +69,7 @@
     <None Include="EXPORTS.g.DEF" />
     <None Include="include\ReadMe.md" />
     <None Include="NuGet.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AnalysisBindings.cpp" />
@@ -96,9 +110,13 @@
     <ClInclude Include="include\libllvm-c\TargetRegistrationBindings.h" />
     <ClInclude Include="include\libllvm-c\TripleBindings.h" />
     <ClInclude Include="include\libllvm-c\ValueBindings.h" />
+    <ClInclude Include="OutputDebugStream.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)'=='Debug'">
+    <Natvis Include="..\..\llvm-project\llvm\utils\LLVMVisualizers\llvm.natvis" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\llvm-libs.targets" />
@@ -107,8 +125,10 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Message Importance="High" Text="PlatformConfiguration: $(Platform)|$(Configuration)" />
-    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.props'))" />
-    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.6\build\Ubiquity.NET.Versioning.Build.Tasks.targets'))" />
+    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.props'))" />
+    <Error Condition="!Exists('$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesRoot)Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.targets'))" />
+    <Error Condition="!Exists('..\..\BuildOutput\packages\Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\BuildOutput\packages\Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.props'))" />
+    <Error Condition="!Exists('..\..\BuildOutput\packages\Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\BuildOutput\packages\Ubiquity.NET.Versioning.Build.Tasks.5.0.7-alpha.0.1\build\Ubiquity.NET.Versioning.Build.Tasks.targets'))" />
   </Target>
   <Target Name="AlwaysShowBuildParams" AfterTargets="ShowBuildParams">
     <Message Importance="High" Text="FullBuildNumber: $(FullBuildNumber)" />
@@ -122,7 +142,7 @@
   -->
   <Target Name="AppendVesionInfoHeader" AfterTargets="GenerateVesionInfoHeader">
     <ItemGroup>
-      <_FullVersionLine Include='#define FULL_BUILD_NUMBER_STRING "$(FullBuildNumber)"'/>
+      <_FullVersionLine Include="#define FULL_BUILD_NUMBER_STRING &quot;$(FullBuildNumber)&quot;" />
     </ItemGroup>
     <WriteLinesToFile File="$(IntermediateOutputPath)$(GeneratedVersionInfoHeader)" Lines="@(_FullVersionLine)" />
   </Target>

--- a/src/LibLLVM/LibLLVM.vcxproj.filters
+++ b/src/LibLLVM/LibLLVM.vcxproj.filters
@@ -15,7 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="cpp.hint" />
     <None Include="include\ReadMe.md">
       <Filter>Header Files</Filter>
@@ -24,6 +23,7 @@
       <Filter>Source Files</Filter>
     </None>
     <None Include="NuGet.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="InlinedExports.cpp">
@@ -135,5 +135,11 @@
     <ClInclude Include="CSemVer.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="OutputDebugStream.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="..\..\llvm-project\llvm\utils\LLVMVisualizers\llvm.natvis" />
   </ItemGroup>
 </Project>

--- a/src/LibLLVM/LlvmApplication.props
+++ b/src/LibLLVM/LlvmApplication.props
@@ -21,6 +21,9 @@
   The DEBUG build is too large and cumbersome to manage using "FREE/OSS" build infrastructure.
   -->
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PropertyGroup>
+      <LinkIncremental>false</LinkIncremental>
+    </PropertyGroup>
     <ClCompile>
       <AdditionalOptions>%(AdditionalOptions) /Zc:__cplusplus /bigobj -w14062 /Gw /EHs-c-</AdditionalOptions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
@@ -51,6 +54,43 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>EXPORTS.g.DEF</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PropertyGroup>
+      <LinkIncremental>false</LinkIncremental>
+    </PropertyGroup>
+    <ClCompile>
+      <AdditionalOptions>%(AdditionalOptions) /Zc:__cplusplus /bigobj -w14062 /Gw /EHs-c-</AdditionalOptions>
+      <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
+      <AdditionalIncludeDirectories>include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DisableSpecificWarnings>4141;4146;4244;4267;4291;4351;4456;4457;4458;4459;4503;4624;4722;4100;4127;4512;4505;4610;4510;4702;4245;4706;4310;4701;4703;4389;4611;4805;4204;4577;4091;4592;4319;4709;5105;4324;4251;4275</DisableSpecificWarnings>
+      <ExceptionHandling />
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>Disabled</Optimization>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <RemoveUnreferencedCodeData>false</RemoveUnreferencedCodeData>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <TreatSpecificWarningsAsErrors>4238</TreatSpecificWarningsAsErrors>
+      <UseFullPaths>false</UseFullPaths>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <WarningLevel>Level4</WarningLevel>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;DEBUG;_HAS_EXCEPTIONS=0;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_NONSTDC_NO_WARNINGS;_SCL_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;UNICODE;_UNICODE;__STDC_CONSTANT_MACROS;__STDC_FORMAT_MACROS;__STDC_LIMIT_MACROS;CMAKE_INTDIR="Debug"</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <ScanSourceForModuleDependencies>false</ScanSourceForModuleDependencies>
+      <SupportJustMyCode>true</SupportJustMyCode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>false</EnableCOMDATFolding>
+      <OptimizeReferences>false</OptimizeReferences>
       <ModuleDefinitionFile>EXPORTS.g.DEF</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/src/LibLLVM/OrcJITv2Bindings.cpp
+++ b/src/LibLLVM/OrcJITv2Bindings.cpp
@@ -2,6 +2,9 @@
 #include <llvm/Support/Error.h>
 #include <llvm/Support/CBindingWrapping.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/SymbolStringPool.h>
+
+#include "OutputDebugStream.h"
 
 using namespace llvm;
 using namespace llvm::orc;
@@ -10,6 +13,11 @@ namespace
 {
     DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ExecutionSession, LLVMOrcExecutionSessionRef)
     DEFINE_SIMPLE_CONVERSION_FUNCTIONS(JITDylib, LLVMOrcJITDylibRef)
+    DEFINE_SIMPLE_CONVERSION_FUNCTIONS(SymbolStringPool, LLVMOrcSymbolStringPoolRef)
+    inline SymbolStringPoolEntryUnsafe unwrap(LLVMOrcSymbolStringPoolEntryRef E)
+    {
+        return reinterpret_cast<SymbolStringPoolEntryUnsafe::PoolEntry*>(E);
+    }
 }
 
 extern "C"
@@ -17,5 +25,34 @@ extern "C"
     LLVMErrorRef LibLLVMExecutionSessionRemoveDyLib(LLVMOrcExecutionSessionRef session, LLVMOrcJITDylibRef lib)
     {
         return wrap(unwrap(session)->removeJITDylib(*unwrap(lib)));
+    }
+
+    LLVMBool LibLLVMOrcSymbolStringPoolIsEmpty(LLVMOrcSymbolStringPoolRef SSP)
+    {
+        return unwrap(SSP)->empty();
+    }
+
+    char* LibLLVMOrcSymbolStringPoolGetDiagnosticRepresentation(LLVMOrcSymbolStringPoolRef SSP)
+    {
+        std::string Messages;
+        raw_string_ostream MsgsOS(Messages);
+        SymbolStringPool& pool = *unwrap(SSP);
+        MsgsOS << pool;
+        return strdup(Messages.c_str());
+    }
+
+    void LibLLVMOrcSymbolStringPoolWriteDebugRepresentation(LLVMOrcSymbolStringPoolRef SSP)
+    {
+        SymbolStringPool const& pool = *unwrap(SSP);
+        LibLLVM::raw_debug_ostream dbgStrm;
+        dbgStrm << "+LibLLVMOrcSymbolStringPoolWriteDebugRepresentation";
+        dbgStrm << pool;
+        dbgStrm << "-LibLLVMOrcSymbolStringPoolWriteDebugRepresentation";
+    }
+
+    size_t LibLLVMOrcSymbolStringPoolGetRefCount(LLVMOrcSymbolStringPoolEntryRef sspe)
+    {
+        SymbolStringPoolEntryUnsafe::PoolEntry* p = unwrap(sspe).rawPtr();
+        return p->getValue();
     }
 }

--- a/src/LibLLVM/OutputDebugStream.h
+++ b/src/LibLLVM/OutputDebugStream.h
@@ -1,0 +1,76 @@
+#ifndef _OUTPUTDEBUGSTREAM_H_
+#define _OUTPUTDEBUGSTREAM_H_
+
+#if defined(DEBUG) || !defined(NDEBUG)
+#include <ios>
+#include <sstream>
+#include <ostream>
+#endif
+
+#if defined(_WIN32)
+#include <Windows.h>
+#endif
+
+#include <llvm/Support/raw_os_ostream.h>
+
+namespace LibLLVM
+{
+// Currently only windows DEBUG builds provide support for debug output
+// It is at least plausible to extend to other platforms if they have
+// equivalent APIs to ::OutputDebugString(A|W) in Windows.
+#if defined(_WIN32) && defined(DEBUG)
+    ////////////////////////////////////////////////////
+    // Description:
+    //    C++ stream buffer for Win32 OutputDebugString()
+    //
+    class OutputDebugStreamBuffer
+        : public std::stringbuf
+    {
+    public:
+        OutputDebugStreamBuffer()
+            : std::stringbuf(std::ios_base::out)
+        {
+        }
+
+    protected:
+        virtual int sync() override
+        {
+            ::OutputDebugStringA(std::stringbuf::str().c_str());
+            str("");
+            return 0;
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////
+    // Description:
+    //    C++ stream class for Win32 OutputDebugString()
+    //
+    class OutputDebugStream
+        : public std::ostream
+    {
+        OutputDebugStreamBuffer Buf;
+
+    public:
+        OutputDebugStream()
+            : std::ostream(&Buf, false)
+        {
+            clear();
+        }
+    };
+
+    inline OutputDebugStream cdbg;
+
+    class raw_debug_ostream
+        : public llvm::raw_os_ostream
+    {
+    public:
+        raw_debug_ostream()
+            : llvm::raw_os_ostream(cdbg)
+        {
+        }
+    };
+#else
+    using raw_debug_ostream = llvm::raw_null_ostream;
+#endif
+}
+#endif

--- a/src/LibLLVM/TargetRegistrationBindings.cpp
+++ b/src/LibLLVM/TargetRegistrationBindings.cpp
@@ -14,7 +14,7 @@ using namespace std::string_view_literals;
 
 // THESE targets are apparently "experimental";
 // They do NOT appear in targets.def, AsmPrinters.def, AsmParsers.def, or Disassemblers.def.
-// Therefore they do NOT get any LLVM-C declarations in Target.h; If desired, declarations
+// Therefore, they do NOT get any LLVM-C declarations in Target.h; If desired, declarations
 // (forward refs really) may be added here but any consumption of them in calling code should
 // get a clear "experimental" remark.
 //

--- a/src/LibLLVM/include/libllvm-c/OrcJITv2Bindings.h
+++ b/src/LibLLVM/include/libllvm-c/OrcJITv2Bindings.h
@@ -5,6 +5,29 @@
 
 LLVM_C_EXTERN_C_BEGIN
     LLVMErrorRef LibLLVMExecutionSessionRemoveDyLib(LLVMOrcExecutionSessionRef session, LLVMOrcJITDylibRef lib);
+
+    // Determines if a string pool is empty. This is generally only used as a diagnostic in
+    // disposers to detect erroneous ref count handling for strings in the pool.
+    // Returns a true boolean (e.g. it returns a non-zero value (true) if the pool is empty and
+    // a 0 value (false) if it is NOT empty)
+    LLVMBool LibLLVMOrcSymbolStringPoolIsEmpty(LLVMOrcSymbolStringPoolRef SSP);
+
+    // Diagnostic for getting a formatted version of the pool
+    // Return requires LLVMDisposeMessage()
+    char* LibLLVMOrcSymbolStringPoolGetDiagnosticRepresentation(LLVMOrcSymbolStringPoolRef SSP);
+
+    // Diagnostic for getting the current ref count for a symbol
+    // This is an inherently unreliable value in that it is an atomic count meaning
+    // ANY thread may manipulate it's value. Thus, the return is mostly meaningless
+    // and useful ONLY in very limited diagnostic conditions.
+    size_t LibLLVMOrcSymbolStringPoolGetRefCount(LLVMOrcSymbolStringPoolEntryRef sspe);
+
+    // Write contents of the pool to the debugger (if attached)
+    // Currently only supported on Windows, but theoretically could operate on other
+    // platforms. Any unsupported platform is a simple NOP. This is useful in tracking
+    // down reference count leaking or pre-mature release scenarios. It is NOT of ANY
+    // value in a retail build (It's a NOP).
+    void LibLLVMOrcSymbolStringPoolWriteDebugRepresentation(LLVMOrcSymbolStringPoolRef SSP);
 LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/packages.config
+++ b/src/LibLLVM/packages.config
@@ -1,10 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <!--
-  This must match the import tags for the props and targets file as well as the NuGet file check
-  in the VCXPROJ file. (Sadly VCXPROJ only uses packages.config, and that does not support version
-  minimum ranges, it has to be exact... [Yet another reason to ditch VCXPROJ in favor of CMAKE
-  and custom scripts.]
-  -->
-  <package id="Ubiquity.NET.Versioning.Build.Tasks" version="5.0.6" targetFramework="native" />
+  <package id="Ubiquity.NET.Versioning.Build.Tasks" version="5.0.7-alpha.0.1" targetFramework="native" />
 </packages>

--- a/src/LibLLVMNative.slnx
+++ b/src/LibLLVMNative.slnx
@@ -45,7 +45,7 @@
     <Platform Project="AnyCPU" />
   </Project>
   <Project Path="LibLLVM/LibLLVM.vcxproj" Id="6c77a7de-d464-430f-96a9-a64768763b5f">
-    <BuildType Project="Release" />
+    <BuildType Solution="Debug|Any CPU" Project="Release" />
   </Project>
   <Project Path="LibLLVMNuget/LibLLVmNuget.csproj" />
   <Project Path="LlvmBindingsGenerator/LlvmBindingsGenerator.csproj" />

--- a/src/LlvmBindingsGenerator/LibLlvmGeneratorLibrary.cs
+++ b/src/LlvmBindingsGenerator/LibLlvmGeneratorLibrary.cs
@@ -26,6 +26,7 @@ namespace LlvmBindingsGenerator
             CmdLineOptions = options;
 
             CommonInclude = Path.Combine( options.LlvmRoot, "include" );
+            CMakeConfigInclude = Path.Combine( options.ConfigPathRoot, "include");
 
             // NOTE: The target specific LLVMInitializeXXX APIs are included in CMAKE generated headers
             // This is OK as they should NOT appear in the set of APIs exported from the library anyway
@@ -59,6 +60,7 @@ namespace LlvmBindingsGenerator
 
             driver.ParserOptions.AddIncludeDirs( CommonInclude );
             driver.ParserOptions.AddIncludeDirs( ExtensionsInclude );
+            driver.ParserOptions.AddIncludeDirs( CMakeConfigInclude );
 
             var coreHeaders = Directory.EnumerateFiles( Path.Combine( CommonInclude, "llvm-c" ), "*.h", SearchOption.AllDirectories );
             var extHeaders = Directory.EnumerateFiles( Path.Combine( ExtensionsInclude, "libllvm-c" ), "*.h", SearchOption.AllDirectories );
@@ -110,6 +112,7 @@ namespace LlvmBindingsGenerator
         private readonly GeneratorConfig Configuration = new();
 
         private readonly string CommonInclude;
+        private readonly string CMakeConfigInclude;
         private readonly string ExtensionsInclude;
         private readonly Options CmdLineOptions;
     }

--- a/src/LlvmBindingsGenerator/Options.cs
+++ b/src/LlvmBindingsGenerator/Options.cs
@@ -20,6 +20,7 @@ namespace LlvmBindingsGenerator
             string? llvmRoot,
             string? extensionsRoot,
             string? exportsDefFilePath,
+            string? configPathRoot,
             DiagnosticKind diagnostics
             )
         {
@@ -32,16 +33,20 @@ namespace LlvmBindingsGenerator
             // by this constructor are buried/lost.
             LlvmRoot = llvmRoot is null ? string.Empty : Path.GetFullPath(llvmRoot);
             ExtensionsRoot = extensionsRoot is null ? string.Empty : Path.GetFullPath(extensionsRoot);
+            ConfigPathRoot = configPathRoot is null ? string.Empty : Path.GetFullPath(configPathRoot);
             ExportsDefFilePath = exportsDefFilePath is null ? string.Empty : Path.GetFullPath(exportsDefFilePath);
 
             Diagnostics = diagnostics;
         }
 
-        [Option('l', HelpText = "Root of source with the LLVM headers to parse (Assumes a subfolder 'include')", Required = true )]
+        [Option('l', HelpText = "Root of source with the LLVM headers to parse (Requires a sub-folder 'include')", Required = true )]
         public string LlvmRoot { get; } = string.Empty;
 
-        [Option('e', HelpText = "Root of source with the LibLLVM extension headers to parse", Required = true )]
+        [Option('e', HelpText = "Root of source with the LibLLVM extension headers to parse (Requires a sub-folder 'include')", Required = true )]
         public string ExtensionsRoot { get; } = string.Empty;
+
+        [Option('i', HelpText = "Root of source with the CMAKE generated LLVM config headers to parse (Requires a sub-folder 'include')", Required = true )]
+        public string ConfigPathRoot { get; } = string.Empty;
 
         [Option('d', HelpText = "Output path for the generated DEF file (For Windows LibLLVM.DLL). Not generated if this is not provided")]
         public string ExportsDefFilePath { get; } = string.Empty;
@@ -65,6 +70,18 @@ namespace LlvmBindingsGenerator
             if(!Directory.Exists(Path.Combine(LlvmRoot, "include")))
             {
                 helpWriter.WriteLine($"LlvmRoot path does not contain a sub folder named 'include'; LlvmRoot: '{LlvmRoot}'.");
+                retVal = false;
+            }
+
+            if(!Directory.Exists(ConfigPathRoot))
+            {
+                helpWriter.WriteLine($"CMake Config path does not exist '{ConfigPathRoot}'.");
+                retVal = false;
+            }
+
+            if(!Directory.Exists(Path.Combine(ConfigPathRoot, "include")))
+            {
+                helpWriter.WriteLine($"ConfigPathRoot does not contain a sub folder named 'include'; ConfigPathRoot: '{ConfigPathRoot}'.");
                 retVal = false;
             }
 
@@ -103,6 +120,7 @@ namespace LlvmBindingsGenerator
             bldr.AppendLine()
                 .AppendLine(CultureInfo.InvariantCulture, $"          LlvmRoot: {LlvmRoot}" )
                 .AppendLine(CultureInfo.InvariantCulture, $"    ExtensionsRoot: {ExtensionsRoot}")
+                .AppendLine(CultureInfo.InvariantCulture, $"    ConfigPathRoot: {ConfigPathRoot}")
                 .AppendLine(CultureInfo.InvariantCulture, $"ExportsDefFilePath: {ExportsDefFilePath}")
                 .AppendLine(CultureInfo.InvariantCulture, $"       Diagnostics: {Diagnostics}");
             return bldr.ToString();

--- a/src/LlvmBindingsGenerator/Templates/readme.md
+++ b/src/LlvmBindingsGenerator/Templates/readme.md
@@ -1,71 +1,16 @@
 ﻿# Ubiquity.NET.Llvm.Interop Generation 
-The code generation for the Ubiquity.NET.Llvm.Interop namespace leverages [CppSharp] for parsing and processing
-the LLVM-C (and custom extension) headers. The actual code generation is done using a custom system of
-T4 templates. While CppSharp has a code generation system it is focused primarily on projecting the full
-C++ type system (including implementing derived types in C#!). However, the generation is pretty inflexible
-when it comes to the final form of the output in C# and how it handles marshaling. Ubiquity.NET.Llvm uses custom
-handle types for all references in the C API along with custom string marshaling to handle the various kinds
-of string disposal used in the C API. Unfortunately, CppSharp wasn't flexible enough to handle that with it's
-built-in generation. Thus, the Ubiquity.NET.Llvm.Interop bindings are generated using customized support based on a
-few T4 templates.
+The code generation for the Ubiquity.NET.Llvm.Interop namespace leverages [CppSharp] for
+parsing and processing the LLVM-C (and custom extension) headers. The actual code generation
+is done using a custom system of T4 templates. While CppSharp has a code generation system
+it is focused primarily on projecting the full C++ type system (including implementing
+derived types in C#!). However, the generation is pretty inflexible when it comes to the
+final form of the output in C# and how it handles marshaling. Ubiquity.NET.Llvm uses custom
+handle types for all references in the C API along with custom string marshaling to handle
+the various kinds of string disposal used in the C API. Unfortunately, CppSharp wasn't
+flexible enough to handle that with it's built-in generation. This variant of the generator
+deals only with the Windows `exports.def
 
 ## T4 Templates
-### ContextHandleTemplate.tt
-Provides a template for all Context handles (see below for details of handles)
+### GlobalHaExportsTemplate.tt
+Provides a template for generation of the Windows Exports.def file
 
-### GlobalHandleTemplate.tt
-Provides a template for all Global handles (see below for details of handles)
-
-### LLVMErrorRefTemplate.tt
-Specialized template for handling LLVMErrorRef, which has multiple disposal APIs
-
-### PerHeaderInteropTemplate.tt
-This is the main template used to generate the interop for a given parsed header. It includes all the enums
-structures, delegates and P/Invoke calls defined to match the headers.
-
-### StringMarshalerTemplate.tt
-This contains the template for custom string marshaling that incorporates the appropriate cleanup
-handling depending on the requirements of the API. (Sadly, the LLVM-C API is not consistent with how
-this is handled)
-
-## LLVM-C Handle wrappers
-
-Handles for LLVM are just opaque pointers. THey generally come in one of three forms.
-
-  1. Context owned  
-     Where there is always a well known owner that ultimately is responsible for
-     disposing/releasing the resource.
-  2. Global resources  
-     Where there is no parent child ownership relationship and callers must manually release the resource
-  3. An unowned alias to a global resource  
-     This occurs when a child of a global resource contains a reference to the parent. In such
-     a case the handle should be considered like an alias and not disposed.
-
-The Handle implementations here follow consistent patterns for implementing each form of handle.
-
-### Contextual handles
-
-These handles are never manually released or disposed, though releasing their containers will make them
-invalid. The general pattern for implementing such handles is taken care of by the T4 template
-`ContextHandleTemplate.tt`
-
-### Global Handles
-Global handles require the caller to explicitly release the resources.
-In Ubiquity.NET.Llvm these are managed with the .NET SafeHandles types through
-an Ubiquity.NET.Llvm specific derived type LlvmObject. Thus, all resources in
-LLVM requiring explicit release are handled consistently by the T4 template `GlobalHandleTemplate.tt`
-
-### Global Alias handles
-Global alias handles are a specialized form of global handles where they do not
-participate in ownership control/release. These are commonly used when a child
-of a global container exposes a property that references the parent container.
-In such cases the reference retrieved from the child shouldn't be used to destroy
-the child or the parent when no longer used.
-
-In Ubiquity.NET.Llvm this is represented as a distinct context handle type that has
-implicit casting to allow for simpler usage scenarios. (That, is an alias can cast to
-an unowned global handle when needed to allow passing it in to native APIs without
-taking ownership) Most APIs will have the alias type as the signature, especially for
-[In] parameters. This helps to re-inforce the intended semantics for the parameter. To
-make life easy there is an implicit cast from the global handle to an alias (which is
-just a value type) when needed.


### PR DESCRIPTION
Enabled local debug builds
* Update project/build support to enable local developer full debug builds for diagnosing interop crashes.
* Updated readme for generator to reflect split of functionality
* Added debugging aids to diagnose problems with symbol ref counts in wrapper layers.