### PR TITLE
Misc. Updates to correct versioning of native meta package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,6 +45,9 @@
         <IsPullRequestBuild Condition="'$(IsPullRequestBuild)'==''">false</IsPullRequestBuild>
         <IsReleaseBuild Condition="'$(IsReleaseBuild)'==''">false</IsReleaseBuild>
         <BuildTime Condition="'$(BuildTime)'=='' AND '$(APPVEYOR_REPO_COMMIT_TIMESTAMP)'!=''">$(APPVEYOR_REPO_COMMIT_TIMESTAMP)</BuildTime>
+
+        <!-- For diagnostics of versioning, show version info during build -->
+        <!--<ShowVersioning>true</ShowVersioning>-->
     </PropertyGroup>
     <Choose>
         <!-- Apply standard properties for all C# projects -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project InitialTargets="VerifyProjectSettings;ShowBuildParameters">
+<Project InitialTargets="VerifyProjectSettings">
     <!--
     It is tempting to place the SDK ref here so that all the projects benefit from it
     However, since this repo has C++ VCXPROJ projects, that doesn't work. It will pull
@@ -65,19 +65,22 @@
         <MakeDir Directories="$(PackageOutputPath)"/>
     </Target>
 
-    <Target Name="ShowBuildParameters">
-        <Message Importance="normal" Text="              BuildRootDir: $(BuildRootDir)" />
-        <Message Importance="normal" Text="       BaseBuildOutputPath: $(BaseBuildOutputPath)" />
-        <Message Importance="normal" Text="    BaseBuildOutputBinPath: $(BaseBuildOutputBinPath)" />
-        <Message Importance="normal" Text="BaseIntermediateOutputPath: $(BaseIntermediateOutputPath)" />
-        <Message Importance="normal" Text="                    IntDir: $(IntDir)" />
-        <Message Importance="normal" Text="            BaseOutputPath: $(BaseOutputPath)" />
-        <Message Importance="normal" Text="           FullBuildNumber: $(FullBuildNumber)"/>
-        <Message Importance="normal" Text="            PackageVersion: $(PackageVersion)"/>
-        <Message Importance="normal" Text="               FileVersion: $(FileVersion)"/>
-        <Message Importance="normal" Text="               LlvmVersion: $(LlvmVersion)"/>
-        <Message Importance="normal" Text="                  Platform: $(Platform)"/>
-        <Message Importance="normal" Text="             Configuration: $(Configuration)"/>
+    <Target Name="ShowBuildParameters" AfterTargets="PrepareVersioningForBuild" Condition="'$(ShowVersioning)'=='true'">
+        <Message Importance="high" Text="-------------------------------------------"/>
+        <Message Importance="high" Text="                   Project: $(MSBuildProjectFile)" />
+        <Message Importance="high" Text="              BuildRootDir: $(BuildRootDir)" />
+        <Message Importance="high" Text="       BaseBuildOutputPath: $(BaseBuildOutputPath)" />
+        <Message Importance="high" Text="    BaseBuildOutputBinPath: $(BaseBuildOutputBinPath)" />
+        <Message Importance="high" Text="BaseIntermediateOutputPath: $(BaseIntermediateOutputPath)" />
+        <Message Importance="high" Text="                    IntDir: $(IntDir)" />
+        <Message Importance="high" Text="            BaseOutputPath: $(BaseOutputPath)" />
+        <Message Importance="high" Text="           FullBuildNumber: $(FullBuildNumber)"/>
+        <Message Importance="high" Text="            PackageVersion: $(PackageVersion)"/>
+        <Message Importance="high" Text="               FileVersion: $(FileVersion)"/>
+        <Message Importance="high" Text="               LlvmVersion: $(LlvmVersion)"/>
+        <Message Importance="high" Text="                  Platform: $(Platform)"/>
+        <Message Importance="high" Text="             Configuration: $(Configuration)"/>
+        <Message Importance="high" Text="-------------------------------------------"/>
     </Target>
 
     <Target Name="VerifyProjectSettings" Condition="'$(MSBuildProjectExtension)'=='.csproj'">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     [read - never gonna happen])
     -->
   <ItemGroup>
-    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.6" Condition="'$(MSBuildProjectExtension)' != '.vcxproj'" />
+    <GlobalPackageReference Include="Ubiquity.NET.Versioning.Build.Tasks" Version="5.0.7-alpha.0.1" Condition="'$(MSBuildProjectExtension)' != '.vcxproj'" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" Condition="'$(NoCommonAnalyzers)' != 'true'" />
     <GlobalPackageReference Include="IDisposableAnalyzers" Version="4.0.8" Condition="'$(NoCommonAnalyzers)' != 'true'" />
     <GlobalPackageReference Include="MustUseRetVal" Condition="'$(NoCommonAnalyzers)' != 'true'" Version="0.0.2" />
@@ -17,7 +17,7 @@
         This has NO use on C/C++ builds, and in fact NuGet is screwed up if it is included such that it WON'T resolve entries
         in packages.config (It seems to think it's a PackageReferences project even though it most definitely is NOT!)
         -->
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(UseStyleCop)' != 'false' AND '$(MSBuildProjectExtension)'!='.vcxproj'" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(NoCommonAnalyzers)' != 'true' AND '$(UseStyleCop)' != 'false' AND '$(MSBuildProjectExtension)'!='.vcxproj'" />
   </ItemGroup>
   <!--
     Package versions made consistent across all packages referenced in this repository

--- a/OneFlow/Start-FakeRelease.ps1
+++ b/OneFlow/Start-FakeRelease.ps1
@@ -1,0 +1,37 @@
+using module '../PSModules/CommonBuild/CommonBuild.psd1'
+using module '../PsModules/RepoBuild/RepoBuild.psd1'
+
+<#
+.SYNOPSIS
+    Sets environment variable to fake an automated release build
+
+.DESCRIPTION
+    This is used for internal developer testing only. It allows validation and debugging of
+    portions of scripts and builds that is only available for formal automated builds. Since,
+    debugging an actual automated build is not possible this is the closest thing possible.
+
+.PARAMETER Force
+    Bypasses confirmation prompts and clears the environment variables for the build.
+#>
+[cmdletbinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+Param([switch]$Force)
+
+if ($Force -and -not $PSBoundParameters.ContainsKey('Confirm'))
+{
+    $ConfirmPreference = 'None'
+}
+
+if($PSCmdlet.ShouldProcess("Environment", "Start Fake release"))
+{
+    # pretend running in GitHub Actions
+    $env:GITHUB_ACTIONS = "true"
+    $env:GITHUB_REF = 'refs/tags/fake-release-1234'
+
+    $buildInfo = Initialize-BuildEnvironment
+    if($buildInfo['CurrentBuildKind'] -ne 'ReleaseBuild')
+    {
+        throw "Build info indicates something other than a release build: '{$buildInfo['CurrentBuildKind']}'"
+    }
+}
+
+

--- a/OneFlow/Stop-FakeRelease.ps1
+++ b/OneFlow/Stop-FakeRelease.ps1
@@ -1,0 +1,30 @@
+using module '../PSModules/CommonBuild/CommonBuild.psd1'
+using module '../PsModules/RepoBuild/RepoBuild.psd1'
+
+<#
+.SYNOPSIS
+    Clears environment variables used to fake an automated release build
+
+.DESCRIPTION
+    This is used for internal developer testing only. It allows validation and debugging of
+    portions of scripts and builds that is only available for formal automated builds. Since,
+    debugging an actual automated build is not possible this is the closest thing possible.
+
+.PARAMETER Force
+    Bypasses confirmation prompts and clears the environment variables for the build.
+#>
+[cmdletbinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+Param([switch]$Force)
+
+if ($Force -and -not $PSBoundParameters.ContainsKey('Confirm'))
+{
+    $ConfirmPreference = 'None'
+}
+
+if($PSCmdlet.ShouldProcess("Environment", "Stop Fake release"))
+{
+    # clear values set in Start-FakeRelease.ps1
+    $env:GITHUB_ACTIONS = $null
+    $env:GITHUB_REF = $null
+}
+

--- a/src/LibLLVMNative.slnx
+++ b/src/LibLLVMNative.slnx
@@ -37,6 +37,8 @@
     <File Path="../OneFlow/Publish-Release.ps1" />
     <File Path="../OneFlow/ReadMe.md" />
     <File Path="../OneFlow/Start-Release.ps1" />
+    <File Path="Start-FakeRelease.ps1" />
+    <File Path="Stop-FakeRelease.ps1" />
   </Folder>
   <Project Path="../PsModules/CommonBuild/CommonBuild.pssproj" Type="f5034706-568f-408a-b7b3-4d38c6db8a32" Id="6cafc0c6-a428-4d30-a9f9-700e829fea51">
     <Platform Project="AnyCPU" />

--- a/src/LlvmBindingsGenerator/ReadMe.md
+++ b/src/LlvmBindingsGenerator/ReadMe.md
@@ -13,8 +13,8 @@ Instead it is now split into two uses:
     1) This version in the native repo deals only with the export generation and name
        validation for the extension APIs
 2) Generates the "safe handle" C# code from the LLVM + LIBLLVM headers
-    1) This functionality moved to the consuming repo where it is easier to maintain and
-       update as all the upward managed dependencies are there.
+    1) ***This functionality moved to the consuming repo where it is easier to maintain and
+       update as all the upward managed dependencies are there.***
 
 ## Usage
 `LlvmBindingsGenerator -l <llvmRoot> -e <ExtensionsRoot> -d <ExportsDefFilePath> -Diagnostics <Diagnostics>`

--- a/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.csproj
+++ b/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.csproj
@@ -1,15 +1,15 @@
 ﻿<!--
 Project to build the NUGET Meta package
+
+NOTE:
+To support a meta package where the referenced packages may not exist at build time this must use a NUSPEC file directly.
+The Build process for CSPROJ files will require resolving the referenced packages before it "generates" the NuSpec file.
+The CSPROJ system for MSBUILD will try to restore referenced packages etc... and basically requires the ability to find
+the listed dependencies. (They won't exist yet for this build/repo)
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!--
-    To support a meta package where the referenced packages may not exist at build time this must use a NUSPEC file directly.
-    The Build process for CSPROJ files will require resolving the referenced packages before it "generates" the NuSpec file.
-    The CSPROJ system for MSBUILD will try to restore referenced packages etc... and basically requires the ability to find
-    the listed dependencies. (They won't exist yet for this build/repo)
-    -->
     <NuSpecFile>Ubiquity.NET.LibLlvm.nuspec</NuSpecFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
@@ -40,9 +40,16 @@ Project to build the NUGET Meta package
 
   <!--
   Provide the standard properties for this project to the package generation so that the NUSPEC
-  file will complete the pack.
+  file will complete the pack. The DependsOnTarget is REQUIRED as MSBUILD/VS/dotnet CLI all behave differently,
+  especially with regard to release/automated builds. In particular the `PrepareVersioningForBuild` target
+  may not trigger for automated builds on restore/pack even though it does for other targets. The output
+  from that task is observable in the output but apparently the output ignores that it was reloaded (no
+  indication of this happening is provided) so when the actual generation of the Nuspec file comes along,
+  the PackageVersion is default. This now adds the Depends on AND an error if the property is still at the
+  always invalid default setting.
   -->
-  <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">
+  <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="PrepareVersioningForBuild">
+    <Error Code="UNLL001" Condition="'$(PackageVersion)'=='1.0.0'" Text="$PackageVersion has default value!"/>
     <PropertyGroup>
       <NuspecProperties>configuration=$(Configuration)</NuspecProperties>
       <NuspecProperties>$(NuspecProperties);packageID=$(PackageID)</NuspecProperties>


### PR DESCRIPTION
Misc. Updates to correct versioning of native meta package
* Added scripts for local builds to "fake" an automated release build.
* Set version of `Ubiquity.NET.Versioning.Build.Tasks` to correct default.
    * Sadly the native VCXPROJ and SDK style .NET projects use different mechanisms for specifying versioning and it is easy to get them wrong/out of sync.