### PR TITLE
Updated build scripts to properly support a new machine

### DIFF
--- a/Build-LibLLVMAndPackage.ps1
+++ b/Build-LibLLVMAndPackage.ps1
@@ -108,6 +108,16 @@ try
 
         # Need to invoke NuGet directly for restore of vcxproj as /t:Restore target doesn't support packages.config
         # and PackageReference isn't supported for native projects... [Sigh...]
+        if($null -eq (Find-OnPath nuget))
+        {
+            winget install 'Microsoft.NuGet'
+        }
+
+        if($null -eq (Find-OnPath nuget))
+        {
+            throw "NuGet.exe not found, even after installation attempt..."
+        }
+
         Write-Information "Restoring LibLLVM"
         $libLLVMVcxProj = Join-Path 'src' 'LibLLVM' 'LibLLVM.vcxproj'
         Invoke-External nuget restore $libLLVMVcxProj -PackagesDirectory $buildInfo['NuGetRepositoryPath']

--- a/PsModules/CommonBuild/Public/Initialize-CommonBuildEnvironment.ps1
+++ b/PsModules/CommonBuild/Public/Initialize-CommonBuildEnvironment.ps1
@@ -53,73 +53,83 @@ function Initialize-CommonBuildEnvironment
         [switch]$FullInit
     )
 
-    # Script code should ALWAYS use the global CurrentBuildKind
-    $currentBuildKind = Get-CurrentBuildKind
-
-    # set/reset legacy environment vars for non-script tools (i.e. msbuild.exe)
-    $env:IsAutomatedBuild = $currentBuildKind -ne [BuildKind]::LocalBuild
-    $env:IsPullRequestBuild = $currentBuildKind -eq [BuildKind]::PullRequestBuild
-    $env:IsReleaseBuild = $currentBuildKind -eq [BuildKind]::ReleaseBuild
-
-    switch($currentBuildKind)
+    try
     {
-        ([BuildKind]::LocalBuild) { $env:CiBuildName = 'ZZZ' }
-        ([BuildKind]::PullRequestBuild) { $env:CiBuildName = 'PRQ' }
-        ([BuildKind]::CiBuild) { $env:CiBuildName = 'BLD' }
-        ([BuildKind]::ReleaseBuild) { $env:CiBuildName = '' }
-        default { throw "Invalid build kind" }
-    }
+        # Script code should ALWAYS use the global CurrentBuildKind
+        $currentBuildKind = Get-CurrentBuildKind
 
-    # get the ISO-8601 formatted time stamp of the HEAD commit or the current UTC time for local builds
-    # for FullInit force a re-capture of the time stamp.
-    if(!$env:BuildTime -or $FullInit)
+        # set/reset legacy environment vars for non-script tools (i.e. msbuild.exe)
+        $env:IsAutomatedBuild = $currentBuildKind -ne [BuildKind]::LocalBuild
+        $env:IsPullRequestBuild = $currentBuildKind -eq [BuildKind]::PullRequestBuild
+        $env:IsReleaseBuild = $currentBuildKind -eq [BuildKind]::ReleaseBuild
+
+        switch($currentBuildKind)
+        {
+            ([BuildKind]::LocalBuild) { $env:CiBuildName = 'ZZZ' }
+            ([BuildKind]::PullRequestBuild) { $env:CiBuildName = 'PRQ' }
+            ([BuildKind]::CiBuild) { $env:CiBuildName = 'BLD' }
+            ([BuildKind]::ReleaseBuild) { $env:CiBuildName = '' }
+            default { throw "Invalid build kind" }
+        }
+
+        # get the ISO-8601 formatted time stamp of the HEAD commit or the current UTC time for local builds
+        # for FullInit force a re-capture of the time stamp.
+        if(!$env:BuildTime -or $FullInit)
+        {
+            # for any automated builds use the ISO-8601 time stamp of the current commit
+            if($currentBuildKind -ne [BuildKind]::LocalBuild)
+            {
+                $env:BuildTime = (git show -s --format=%cI)
+            }
+            else
+            {
+                $env:BuildTime = ([System.DateTime]::UtcNow.ToString("o"))
+            }
+        }
+
+        # On Windows setup the equivalent of a Developer prompt.
+        #
+        # other platform runners may have different defaulted paths etc...
+        # to account for here.
+        if ($IsWindows)
+        {
+            Write-Verbose "Configuring VS tools support"
+
+            # For windows force a common VS tools prompt;
+            # Sadly most of this is undocumented and found from various sites
+            # spelunking the process. This isn't as bad as it might seem as the
+            # installer will create persistent use of this as a Windows Terminal
+            # "profile" and the actual command is exposed.
+            if($null -eq (Find-OnPath vswhere))
+            {
+                # NOTE: automated builds in Github do NOT include winget (for reasons unknown)
+                # However, they do contain VSWHERE so should not hit this.
+                winget install Microsoft.VisualStudio.Locator | Out-Null
+
+                # location is fixed and the same no matter what version!
+                $env:PATH +=';%ProgramFiles(x86)%\Microsoft Visual Studio\Installer'
+            }
+
+            $vsShellModulePath = vswhere.exe -find **\Microsoft.VisualStudio.DevShell.dll
+            $vsToolsArch = Get-VsArchitecture
+            if(!$vsShellModulePath)
+            {
+                throw "VS shell module not found!"
+            }
+
+            Import-Module $vsShellModulePath | Out-Null
+            $vsInstanceId = vswhere.exe -format value -property InstanceId
+            Enter-VsDevShell $vsInstanceId -SkipAutomaticLocation -DevCmdArguments "-arch=$vsToolsArch -host_arch=$vsToolsArch" | Out-Null
+        }
+
+        #Start with standard build paths then add additional values to the hashtable
+        $buildInfo = Get-DefaultBuildPaths $repoRoot
+        $buildInfo['CurrentBuildKind'] = $currentBuildKind
+        $buildInfo['VersionTag'] = Get-BuildVersionTag $buildInfo
+        return $buildInfo
+    }
+    catch
     {
-        # for any automated builds use the ISO-8601 time stamp of the current commit
-        if($currentBuildKind -ne [BuildKind]::LocalBuild)
-        {
-            $env:BuildTime = (git show -s --format=%cI)
-        }
-        else
-        {
-            $env:BuildTime = ([System.DateTime]::UtcNow.ToString("o"))
-        }
+        throw
     }
-
-    # On Windows setup the equivalent of a Developer prompt.
-    #
-    # other platform runners may have different defaulted paths etc...
-    # to account for here.
-    if ($IsWindows)
-    {
-        Write-Verbose "Configuring VS tools support"
-
-        # For windows force a common VS tools prompt;
-        # Sadly most of this is undocumented and found from various sites
-        # spelunking the process. This isn't as bad as it might seem as the
-        # installer will create persistent use of this as a Windows Terminal
-        # "profile" and the actual command is exposed.
-        if($null -eq (Find-OnPath vswhere))
-        {
-            # NOTE: automated builds in Github do NOT include winget (for reasons unknown)
-            # However, they do contain VSWHERE so should not hit this.
-            winget install Microsoft.VisualStudio.Locator | Out-Null
-        }
-
-        $vsShellModulePath = vswhere -find **\Microsoft.VisualStudio.DevShell.dll
-        $vsToolsArch = Get-VsArchitecture
-        if(!$vsShellModulePath)
-        {
-            throw "VS shell module not found!"
-        }
-
-        Import-Module $vsShellModulePath | Out-Null
-        $vsInstanceId = vswhere -format value -property InstanceId
-        Enter-VsDevShell $vsInstanceId -SkipAutomaticLocation -DevCmdArguments "-arch=$vsToolsArch -host_arch=$vsToolsArch" | Out-Null
-    }
-
-    #Start with standard build paths then add additional values to the hashtable
-    $buildInfo = Get-DefaultBuildPaths $repoRoot
-    $buildInfo['CurrentBuildKind'] = $currentBuildKind
-    $buildInfo['VersionTag'] = Get-BuildVersionTag $buildInfo
-    return $buildInfo
 }


### PR DESCRIPTION
- VSWHERE.EXE is not always on the path, but location is fixed so it can be added
- Nuget.exe is not alwyas present and not installed by VS installation