### PR TITLE
Limit VS Version to VS2022

### DIFF
--- a/Build-All.ps1
+++ b/Build-All.ps1
@@ -3,7 +3,7 @@ using module "PSModules/RepoBuild/RepoBuild.psd1"
 
 <#
 .SYNOPSIS
-    Script to build all of the LLvm.NET Interop code base.
+    Script to build all of the LLvm.NET native code base.
 
 .PARAMETER Configuration
     This sets the build configuration to use, default is "Release" though for inner loop development this
@@ -20,7 +20,7 @@ using module "PSModules/RepoBuild/RepoBuild.psd1"
 
 .DESCRIPTION
     This script is NOT used by the automated build to perform the actual build. Instead this
-    is used to automate local builds and validate stages before committing changes to the repo.
+    is used to automate local builds and validate stages before committing changes to the repository.
     It will serialize the build for the current RID. (The automated build can run
     various stages in parallel, including each RID)
 

--- a/PsModules/CommonBuild/Private/Get-BuildVersionXML.ps1
+++ b/PsModules/CommonBuild/Private/Get-BuildVersionXML.ps1
@@ -12,9 +12,24 @@ function Get-BuildVersionXML
     Hashtable containing Information about the repository and build. This function
     requires the presence of a 'RepoRootPath' property to indicate the root of the
     repository containing the BuildVersion.xml file.
+
+.PARAMETER xmlPath
+    Path of the XML file to retrieve. This is mutually exclusive with the BuildInfo
+    parameter, it is generally only used when developing these build scripts to
+    explicitly retrieve the version from a path without needing the hashtable.
 #>
     [OutputType([xml])]
-    param ($buildInfo)
+    param (
+        [Parameter(Mandatory=$true, ParameterSetName = 'BuildInfo', Position=0)][hashtable] $buildInfo,
+        [Parameter(Mandatory=$true, ParameterSetName = 'Path', Position=0)][string] $xmlPath
+    )
 
-    return [xml](Get-Content (Join-Path $buildInfo['RepoRootPath'] 'BuildVersion.xml'))
+    if ($PsCmdlet.ParameterSetName -eq "BuildInfo")
+    {
+        return [xml](Get-Content (Join-Path $buildInfo['RepoRootPath'] 'BuildVersion.xml'))
+    }
+    else
+    {
+        return [xml](Get-Content $xmlPath)
+    }
 }

--- a/PsModules/CommonBuild/Public/Get-CurrentBuildKind.ps1
+++ b/PsModules/CommonBuild/Public/Get-CurrentBuildKind.ps1
@@ -30,6 +30,9 @@ function Get-CurrentBuildKind
     $currentBuildKind = [BuildKind]::LocalBuild
 
     # IsAutomatedBuild is the top level gate (e.g. if it is false, all the others must be false)
+    # This supports identification of APPVEYOR or GitHub explicitly but also supports the common
+    # `CI` environment variable. Additional build back-ends that don't set the env var therefore,
+    # would need special handling here.
     $isAutomatedBuild = [System.Convert]::ToBoolean($env:CI) `
                         -or [System.Convert]::ToBoolean($env:APPVEYOR) `
                         -or [System.Convert]::ToBoolean($env:GITHUB_ACTIONS)
@@ -39,6 +42,12 @@ function Get-CurrentBuildKind
         # PR and release builds have externally detected indicators that are tested
         # below, so default to a CiBuild (e.g. not a PR, And not a RELEASE)
         $currentBuildKind = [BuildKind]::CiBuild
+
+        # Based on back-end type - determine if this is a release or CI build
+        # The assumption here is that a TAG is pushed to the repo for releases
+        # and therefore that is what distinguishes a release build. Other conditions
+        # would need to use other criteria to determine a PR buddy build, CI build
+        # and release build.
 
         # IsPullRequestBuild indicates an automated buddy build and should not be trusted
         $isPullRequestBuild = $env:GITHUB_BASE_REF -or $env:APPVEYOR_PULL_REQUEST_NUMBER

--- a/PsModules/CommonBuild/Public/Initialize-CommonBuildEnvironment.ps1
+++ b/PsModules/CommonBuild/Public/Initialize-CommonBuildEnvironment.ps1
@@ -89,7 +89,7 @@ function Initialize-CommonBuildEnvironment
 
         # On Windows setup the equivalent of a Developer prompt.
         #
-        # other platform runners may have different defaulted paths etc...
+        # Other platform runners may have different defaulted paths etc...
         # to account for here.
         if ($IsWindows)
         {
@@ -102,7 +102,7 @@ function Initialize-CommonBuildEnvironment
             # "profile" and the actual command is exposed.
             if($null -eq (Find-OnPath vswhere))
             {
-                # NOTE: automated builds in Github do NOT include winget (for reasons unknown)
+                # NOTE: automated builds in GitHub do NOT include WinGet (for reasons unknown)
                 # However, they do contain VSWHERE so should not hit this.
                 winget install Microsoft.VisualStudio.Locator | Out-Null
 
@@ -110,19 +110,22 @@ function Initialize-CommonBuildEnvironment
                 $env:PATH +=';%ProgramFiles(x86)%\Microsoft Visual Studio\Installer'
             }
 
-            $vsShellModulePath = vswhere.exe -find **\Microsoft.VisualStudio.DevShell.dll
+            # explicitly blocks VS2026, VS2022 tools are required for the native LLVM builds.
+            $validVsVersionRange = "[17.0,18.0)"
+            $vsShellModulePath = vswhere -version $validVsVersionRange -find **\Microsoft.VisualStudio.DevShell.dll
             $vsToolsArch = Get-VsArchitecture
             if(!$vsShellModulePath)
             {
                 throw "VS shell module not found!"
             }
 
+            Write-Information "Loading VS Shell Component from: '$vsShellModulePath'"
             Import-Module $vsShellModulePath | Out-Null
-            $vsInstanceId = vswhere.exe -format value -property InstanceId
+            $vsInstanceId = vswhere -version $validVsVersionRange -format value -property InstanceId
             Enter-VsDevShell $vsInstanceId -SkipAutomaticLocation -DevCmdArguments "-arch=$vsToolsArch -host_arch=$vsToolsArch" | Out-Null
         }
 
-        #Start with standard build paths then add additional values to the hashtable
+        #Start with standard build paths then add additional values to the hash-table
         $buildInfo = Get-DefaultBuildPaths $repoRoot
         $buildInfo['CurrentBuildKind'] = $currentBuildKind
         $buildInfo['VersionTag'] = Get-BuildVersionTag $buildInfo
@@ -130,6 +133,11 @@ function Initialize-CommonBuildEnvironment
     }
     catch
     {
+        # everything from the official docs to the various articles in the blog-sphere says this isn't needed
+        # and in fact it is redundant - They're all WRONG! By re-throwing the exception the original location
+        # information is retained and the error reported will include the correct source file and line number
+        # data for the error. Without this, only the error message is retained and the location information is
+        # Line 1, Column 1, of the outer most script file, or the calling location neither of which is useful.
         throw
     }
 }


### PR DESCRIPTION
Limit VS Version to VS2022

* VS/MSVC has breaking changes in the VS2026 libraries and is not viable for builds of LLVM.
   - Most notably missing helper methods etc...
* This PR locks the version used to VS2022 only and does not allow VS2026. So a back-end must have that to work.
* Synchronized most common build modules
    - The VS version limits is currently not repo-specific though it probably should be long term.