### PR TITLE
Implement new extension API to support Alloca with addresspace.

### DIFF
--- a/src/IgnoredWords.dic
+++ b/src/IgnoredWords.dic
@@ -39,6 +39,7 @@ compat
 Concat
 Config
 const
+constexpr
 contentfiles
 Contributors
 crlf
@@ -46,6 +47,7 @@ csharp
 csproj
 de
 defacto
+dereference
 dllimport
 docfx
 docfxconsole
@@ -74,6 +76,7 @@ Interop
 jit
 Lexer
 libllvm
+llvm
 LValue
 malloc
 marshallers
@@ -83,6 +86,7 @@ metadata
 Mips
 msbuild
 msg
+namespace
 nav
 nint
 noinline
@@ -90,6 +94,7 @@ nounwind
 nuint
 nullability
 Nullable
+nullptr
 optimizenone
 pages
 paren
@@ -108,12 +113,14 @@ RMW
 runtimes
 RValue
 sizeof
+Sparc
 src
 Stateful
 stderr
 struct
 structs
 Subrange
+sv
 Sym
 telliam
 tl

--- a/src/LibLLVM/AttributeBindings.cpp
+++ b/src/LibLLVM/AttributeBindings.cpp
@@ -71,10 +71,8 @@ extern "C"
 // VS IDE will see an error E0289 on the definition of AllKnownAttributeNames that is NOT anything
 // that can be suppressed. It's JUST the IDE in editor experience for this declaration. (Hover, over
 // the `AllKnownAttributeNames` in `LibLLVMGetNumKnownAttribs` below and it sees ALL the values.
-// So it's just a problem with the in editor parsing not handling the #include for this limited
-// case. Hopefully this is fixed with:
-// https://developercommunity.visualstudio.com/t/CC-IntelliSense-reports-E0289-no-ins/10618237
-// Though it does not appear to be...
+// So it's just a problem with the in editor parsing/error reporting not handling the #include for
+// this limited case.
 
     constexpr std::array AllKnownAttributeNames = {
 #define GET_ATTR_NAMES

--- a/src/LibLLVM/DiBuilderBindings.cpp
+++ b/src/LibLLVM/DiBuilderBindings.cpp
@@ -1,0 +1,26 @@
+#include <cstdint>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Value.h>
+
+#include <llvm-c/Types.h>
+#include "libllvm-c/DiBuilderBindings.h"
+
+using namespace llvm;
+
+// Sadly, the existing LLVM-C API as of 20.1.8 does not support the address space parameter
+// so this provides extension APIs that are mostly clones of the LLVM-C API but use the
+// address space.
+
+extern "C"
+{
+    LLVMValueRef LibLLVMBuildAlloca(LLVMBuilderRef B, LLVMTypeRef Ty, const char *Name, uint32_t addressSpace)
+    {
+        return wrap(unwrap(B)->CreateAlloca(unwrap(Ty), addressSpace, nullptr, Name));
+    }
+
+    LLVMValueRef LibLLVMBuildArrayAlloca(LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Val, const char *Name, uint32_t addressSpace)
+    {
+        return wrap(unwrap(B)->CreateAlloca(unwrap(Ty), addressSpace, unwrap(Val), Name));
+    }
+}

--- a/src/LibLLVM/LibLLVM.vcxproj
+++ b/src/LibLLVM/LibLLVM.vcxproj
@@ -76,6 +76,7 @@
     <ClCompile Include="AttributeBindings.cpp" />
     <ClCompile Include="ContextBindings.cpp" />
     <ClCompile Include="DataLayoutBindings.cpp" />
+    <ClCompile Include="DiBuilderBindings.cpp" />
     <ClCompile Include="ObjectFileBindings.cpp" />
     <ClCompile Include="InlinedExports.cpp" />
     <ClCompile Include="IRBindings.cpp" />
@@ -100,6 +101,7 @@
     <ClInclude Include="include\libllvm-c\AttributeBindings.h" />
     <ClInclude Include="include\libllvm-c\ContextBindings.h" />
     <ClInclude Include="include\libllvm-c\DataLayoutBindings.h" />
+    <ClInclude Include="include\libllvm-c\DiBuilderBindings.h" />
     <ClInclude Include="include\libllvm-c\IRBindings.h" />
     <ClInclude Include="include\libllvm-c\MetadataBindings.h" />
     <ClInclude Include="include\libllvm-c\ModuleBindings.h" />

--- a/src/LibLLVM/LibLLVM.vcxproj.filters
+++ b/src/LibLLVM/LibLLVM.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClCompile Include="TargetMachineBindings.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DiBuilderBindings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resource.rc">
@@ -134,6 +137,9 @@
     </ClInclude>
     <ClInclude Include="targetver.h">
       <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\libllvm-c\DiBuilderBindings.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/LibLLVM/PassBuilderOptionsBindings.cpp
+++ b/src/LibLLVM/PassBuilderOptionsBindings.cpp
@@ -12,7 +12,7 @@
 using namespace llvm;
 
 // Lifted from llvm/lib/Passes/PassBuilderBindings.cpp as it is not in any headers.
-// it is theoretically supposed to be an internal detail but they didn't
+// It is theoretically supposed to be an internal detail but they didn't
 // provide ANY getter functions for the properties of the class. Thus, this
 // set of extensions is to provide that. The shape of this **MUST** match
 // what is in LLVM and can only be verified by inspection. The version checks

--- a/src/LibLLVM/TargetMachineBindings.cpp
+++ b/src/LibLLVM/TargetMachineBindings.cpp
@@ -12,10 +12,18 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 
-// cloned from llvm/lib/Target/TargetMachineC.cpp
-namespace llvm {
+// Lifted from llvm/lib/Target/TargetMachineC.cpp as it is not in any headers.
+// It is theoretically supposed to be an internal detail but they didn't
+// provide ANY getter functions for the properties of the class. Thus, this
+// set of extensions is to provide that. The shape of this **MUST** match
+// what is in LLVM and can only be verified by inspection. The version checks
+// below will enforce that.
+
+namespace llvm
+{
     /// Options for LLVMCreateTargetMachine().
-    struct LLVMTargetMachineOptions {
+    struct LLVMTargetMachineOptions
+    {
         std::string CPU;
         std::string Features;
         std::string ABI;

--- a/src/LibLLVM/TargetRegistrationBindings.cpp
+++ b/src/LibLLVM/TargetRegistrationBindings.cpp
@@ -355,11 +355,16 @@ namespace
     {
 #if LLVM_HAS_AARCH64_TARGET
         // For reasons unknown, VS IDE thinks these are declared in the .def file and
-        // Happily "suggests" that it should add an include of `llvm/Config/Targets.def`
+        // The IDE will then happily "suggest" that it should add an include of `llvm/Config/Targets.def`
         // But that's not a valid header to include and requires parameters and Multiple inclusion.
         // So - Just say NO!
         if (has_flag(registrations, TargetRegistration_Target))
         {
+            // In VS IDE (2022/2026) - the following line generates the a warning
+            //     VCIC001 : Content from #include <llvm/Config/Targets.def> is used in this file and transitively included
+            // It is COMPLETE BS - see https://developercommunity.visualstudio.com/t/Add-support-for-inline-suppressions-for/10992416
+            // There are 2 issues here, 1) apparently it is supposed to ignore .def files and isn't and 2) That there is no
+            // way to silence it in this specific instance (Not ALL up, just this one case)
             LLVMInitializeAArch64Target();
         }
 
@@ -375,16 +380,22 @@ namespace
 
         if (has_flag(registrations, TargetRegistration_AsmPrinter))
         {
+            // ditto
+            // VCIC001 : Content from #include <llvm/Config/Targets.def> is used in this file and transitively included
             LLVMInitializeAArch64AsmPrinter();
         }
 
         if (has_flag(registrations, TargetRegistration_Disassembler))
         {
+            // ditto
+            // VCIC001 : Content from #include <llvm/Config/Targets.def> is used in this file and transitively included
             LLVMInitializeAArch64Disassembler();
         }
 
         if (has_flag(registrations, TargetRegistration_AsmParser))
         {
+            // ditto
+            // VCIC001 : Content from #include <llvm/Config/Targets.def> is used in this file and transitively included
             LLVMInitializeAArch64AsmParser();
         }
 #endif

--- a/src/LibLLVM/TripleBindings.cpp
+++ b/src/LibLLVM/TripleBindings.cpp
@@ -10,7 +10,10 @@
 
 using namespace llvm;
 
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS( Triple, LibLLVMTripleRef )
+namespace
+{
+    DEFINE_SIMPLE_CONVERSION_FUNCTIONS( Triple, LibLLVMTripleRef )
+}
 
 extern "C"
 {

--- a/src/LibLLVM/include/libllvm-c/AnalysisBindings.h
+++ b/src/LibLLVM/include/libllvm-c/AnalysisBindings.h
@@ -6,10 +6,7 @@
 #include <llvm-c/Types.h>
 
 LLVM_C_EXTERN_C_BEGIN
-    LLVMBool LibLLVMVerifyFunctionEx( LLVMValueRef Fn
-                                      , LLVMVerifierFailureAction Action
-                                      , char** OutMessages
-    );
+    LLVMBool LibLLVMVerifyFunctionEx( LLVMValueRef Fn, LLVMVerifierFailureAction Action, char** OutMessages);
 LLVM_C_EXTERN_C_END
 
 #endif

--- a/src/LibLLVM/include/libllvm-c/AttributeBindings.h
+++ b/src/LibLLVM/include/libllvm-c/AttributeBindings.h
@@ -13,7 +13,12 @@
 
 #ifndef LLVM_BINDINGS_LLVM_ATTRIBUTEBINDINGS_H
 #define LLVM_BINDINGS_LLVM_ATTRIBUTEBINDINGS_H
+
+#if __cplusplus
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 #include <llvm-c/Types.h>
 #include <llvm-c/Error.h>

--- a/src/LibLLVM/include/libllvm-c/DiBuilderBindings.h
+++ b/src/LibLLVM/include/libllvm-c/DiBuilderBindings.h
@@ -1,0 +1,18 @@
+#ifndef LIBLLVM_DIBUILDER_BINDINGS_H
+#define LIBLLVM_DIBUILDER_BINDINGS_H
+
+#if __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
+#include <llvm-c/ExternC.h>
+#include <llvm-c/Types.h>
+
+LLVM_C_EXTERN_C_BEGIN
+    LLVMValueRef LibLLVMBuildAlloca(LLVMBuilderRef B, LLVMTypeRef Ty, const char *Name, uint32_t addressSpace);
+    LLVMValueRef LibLLVMBuildArrayAlloca(LLVMBuilderRef B, LLVMTypeRef Ty, LLVMValueRef Val, const char *Name, uint32_t addressSpace);
+LLVM_C_EXTERN_C_END
+
+#endif

--- a/src/LibLLVM/include/libllvm-c/MetadataBindings.h
+++ b/src/LibLLVM/include/libllvm-c/MetadataBindings.h
@@ -1,7 +1,11 @@
 #ifndef LLVM_BINDINGS_LLVM_METADATABINDINGS_H
 #define LLVM_BINDINGS_LLVM_METADATABINDINGS_H
 
+#if __cplusplus
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 #include <llvm-c/DebugInfo.h>
 #include <llvm-c/ExternC.h>

--- a/src/LibLLVM/include/libllvm-c/ModuleBindings.h
+++ b/src/LibLLVM/include/libllvm-c/ModuleBindings.h
@@ -1,7 +1,11 @@
 #ifndef _MODULE_BINDINGS_H_
 #define _MODULE_BINDINGS_H_
 
+#if __cplusplus
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 #include <llvm-c/Comdat.h>
 #include <llvm-c/ExternC.h>

--- a/src/LibLLVM/include/libllvm-c/PassBuilderOptionsBindings.h
+++ b/src/LibLLVM/include/libllvm-c/PassBuilderOptionsBindings.h
@@ -1,7 +1,11 @@
 #ifndef _LIBLLVM_PASSBUILDEROPTIONS_BINDINGS_H
 #define _LIBLLVM_PASSBUILDEROPTIONS_BINDINGS_H
 
+#if __cplusplus
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 #include <llvm-c/ExternC.h>
 #include <llvm-c/Transforms/PassBuilder.h>

--- a/src/LibLLVM/include/libllvm-c/TargetRegistrationBindings.h
+++ b/src/LibLLVM/include/libllvm-c/TargetRegistrationBindings.h
@@ -1,7 +1,13 @@
 #ifndef _TARGETREGISTRATION_H_
 #define _TARGETREGISTRATION_H_
+
+#if __cplusplus
 #include <cstdint>
 #include <climits>
+#else
+#include <stdint.h>
+#include <limits.h>
+#endif
 
 #include <llvm-c/Error.h>
 #include <llvm-c/ExternC.h>

--- a/src/LibLLVM/include/libllvm-c/ValueBindings.h
+++ b/src/LibLLVM/include/libllvm-c/ValueBindings.h
@@ -1,16 +1,20 @@
 #ifndef _VALUE_BINDINGS_H_
 #define _VALUE_BINDINGS_H_
 
+#if __cplusplus
 #include <cstdint>
+#else
+#include <stdint.h>
+#endif
 
 #include <llvm-c/ExternC.h>
 #include <llvm-c/Types.h>
 
 LLVM_C_EXTERN_C_BEGIN
-    // ordering matters, all distinct values are generated first, then any derived values (e.g. foo = bar + 1), to ensure the
-    // values match expectations of underlying C++ code and don't alter the sequencing as C++ numbers enum values without an
-    // initializer as automatic +1 of the previous value, thus sticking the derived values in at arbitrary locations in the
-    // declaration order would reset the values.
+    // Ordering matters, all distinct values are generated first, then any derived values (e.g. foo = bar + 1), to ensure the
+    // values match expectations of underlying implementation code and don't alter the sequencing as C/C++ numbers enum values
+    // without an initializer as automatic +1 of the previous value, thus sticking the derived values in at arbitrary locations
+    // in the declaration order would reset the values.
 
     typedef enum LibLLVMValueKind
     {
@@ -22,7 +26,7 @@ LLVM_C_EXTERN_C_BEGIN
 #undef HANDLE_MEMORY_VALUE
 #undef HANDLE_INSTRUCTION
 
-// VS IDE will thinks that this is a type instead of a preprocessor token pasting
+// VS IDE will think that `Instruction` is a type instead of a preprocessor token pasting
 // It will "suggest" "resolving" it with an include of `llvm\IR\Instruction.h` which
 // is an absurd thing to do. Just say NO!.
 #define HANDLE_INST(N, OPC, CLASS) OPC##Kind = Instruction##Kind + N,


### PR DESCRIPTION
Implement new extension API to support Alloca with addresspace.
* This allow generators using address spaces to directly support allocas with a different address space ID. The actual address won't change but it is usable to indicate that
an allocation results in a value valid for an address space. This is normally used for runtimes that support some sort of GC/managed reference vs a native pointer. It is useful to distinguish the intended use and that the address space is part of the type of the pointer (even if it is OPAQUE).
* Cleaned up some headers
    - Minor re-formatting
    - Protected wrappers for `<cstdint>` and `<climits>` as those are not formally available for ISO/C compilation.
        - While it is increasingly rare to use a pure C compilation it is plausible and should still be supported.