### PR TITLE
Fixed Nuspec file comments to prevent build errors from substitutions.

### DIFF
--- a/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.nuspec
+++ b/src/Ubiquity.NET.LibLLVM/Ubiquity.NET.LibLLVM.nuspec
@@ -1,19 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-INPUT:
-    $packageID$ - ID of the package
-    $version$ - Version of this package
-    $authors$ - Authors of the package
-    $description$ - Description of the package
-    $tags$ - Tags to mark this package (Helps searching)
-    $licExpression$ - License expression
-    $projectUrl$ - URL for the project
-    $tfmGroup$ - minimum Target Framework needed for the source files
-    $config$ - Configuration for the build (Debug/Release)
-    $llvmproject$ - path to root of the llvm-project location
-    $libllvmroot$ - path to root of the LibLLVM project to get the extended header files from
--->
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<!--
+NOTE: NuSpec Substitution macros all include a leading and trailing `$`. That syntax is
+      not used here to prevent build failures. The substitution is done before XML
+      validation, which could cause these comments to include invalid chars and break
+      the build. The substitution ignores the fact that any such occurrences are in a
+      comment. This is especially problematic for Local, CI, and PR builds of this library
+      as the version could contain a double dash, which is invalid in an XML comment.
+      Because substitution is done in memory the resulting in memory string contains the
+      invalid chars, but the error is reported with a location in the generating project.
+      That is, a completely incorrect source location is reported making it VERY difficult
+      to find the root cause.
+
+INPUT:
+    packageID => ID of the package
+    version => Version of this package
+    authors => Authors of the package
+    description => Description of the package
+    tags => Tags to mark this package (Helps searching)
+    licExpression => License expression
+    projectUrl => URL for the project
+    tfmGroup => minimum Target Framework needed for the source files
+    config => Configuration for the build (Debug/Release)
+    llvmproject => path to root of the llvm-project location
+    libllvmroot => path to root of the LibLLVM project to get the extended header files from
+-->
     <metadata minClientVersion="4.9.0">
         <id>$packageID$</id>
         <version>$version$</version>


### PR DESCRIPTION
Fixed Nuspec file comments to prevent build errors from substitutions.
Fixes #76